### PR TITLE
Regularisation for mode means and covariances

### DIFF
--- a/osl_dynamics/analysis/connectivity.py
+++ b/osl_dynamics/analysis/connectivity.py
@@ -293,15 +293,19 @@ def save(
         "node_size": 10,
         "node_color": "black",
         "edge_cmap": cm["red_transparent_full_alpha_range"],
-        "colorbar": True,
     }
 
-    # Overwrite keyword arguments if passed
-    plot_kwargs = override_dict_defaults(default_plot_kwargs, plot_kwargs)
-
-    # Plot maps
+    # Loop through each connectivity map
     n_modes = conn_map.shape[0]
     for i in trange(n_modes, desc="Saving images", ncols=98):
+
+        # Overwrite keyword arguments if passed
+        kwargs = override_dict_defaults(default_plot_kwargs, plot_kwargs)
+
+        # If all connections are zero don't add a colourbar
+        kwargs["colorbar"] = np.any(conn_map[i] != 0)
+
+        # Plot maps
         output_file = "{fn.parent}/{fn.stem}{i:0{w}d}{fn.suffix}".format(
             fn=Path(filename), i=i, w=len(str(n_modes))
         )
@@ -310,5 +314,5 @@ def save(
             parcellation.roi_centers(),
             edge_threshold=f"{threshold * 100}%",
             output_file=output_file,
-            **plot_kwargs,
+            **kwargs,
         )

--- a/osl_dynamics/inference/layers.py
+++ b/osl_dynamics/inference/layers.py
@@ -316,7 +316,7 @@ class MeanVectorsLayer(layers.Layer):
 
     def call(self, inputs, **kwargs):
         if self.regularizer is not None:
-            self.add_loss(self.regularizer(inputs))
+            self.add_loss(self.regularizer(self.vectors))
         return self.vectors
 
 

--- a/osl_dynamics/inference/layers.py
+++ b/osl_dynamics/inference/layers.py
@@ -262,6 +262,8 @@ class MeanVectorsLayer(layers.Layer):
         Should we learn the vectors?
     initial_value : np.ndarray
         Initial value for the vectors.
+    regularizer : tf.keras.regularizers.Regularizer
+        Regularizer for vectors.
     """
 
     def __init__(
@@ -270,12 +272,15 @@ class MeanVectorsLayer(layers.Layer):
         m,
         learn,
         initial_value,
+        regularizer=None,
         **kwargs,
     ):
         super().__init__(**kwargs)
         self.n = n
         self.m = m
         self.learn = learn
+
+        # Initialisation for vectors
         if initial_value is None:
             self.initial_value = np.zeros([n, m], dtype=np.float32)
         else:
@@ -296,6 +301,9 @@ class MeanVectorsLayer(layers.Layer):
             self.initial_value = initial_value.astype("float32")
         self.vectors_initializer = WeightInitializer(self.initial_value)
 
+        # Regulariser
+        self.regularizer = regularizer
+
     def build(self, input_shape):
         self.vectors = self.add_weight(
             "vectors",
@@ -307,6 +315,8 @@ class MeanVectorsLayer(layers.Layer):
         self.built = True
 
     def call(self, inputs, **kwargs):
+        if self.regularizer is not None:
+            self.add_loss(self.regularizer(inputs))
         return self.vectors
 
 
@@ -327,6 +337,8 @@ class CovarianceMatricesLayer(layers.Layer):
         Should the matrices be learnable?
     initial_value : np.ndarray
         Initial values for the matrices.
+    regularizer : tf.keras.regularizers.Regularizer
+        Regularizer for matrices.
     """
 
     def __init__(
@@ -335,6 +347,7 @@ class CovarianceMatricesLayer(layers.Layer):
         m,
         learn,
         initial_value,
+        regularizer=None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -373,6 +386,9 @@ class CovarianceMatricesLayer(layers.Layer):
             self.initial_flattened_cholesky_factors
         )
 
+        # Regulariser
+        self.regularizer = regularizer
+
     def build(self, input_shape):
         self.flattened_cholesky_factors = self.add_weight(
             "flattened_cholesky_factors",
@@ -384,7 +400,10 @@ class CovarianceMatricesLayer(layers.Layer):
         self.built = True
 
     def call(self, inputs, **kwargs):
-        return self.bijector(self.flattened_cholesky_factors)
+        covariances = self.bijector(self.flattened_cholesky_factors)
+        if self.regularizer is not None:
+            self.add_loss(self.regularizer(covariances))
+        return covariances
 
 
 class CorrelationMatricesLayer(layers.Layer):

--- a/osl_dynamics/inference/regularizers.py
+++ b/osl_dynamics/inference/regularizers.py
@@ -1,0 +1,68 @@
+"""Custom TensorFlow regularizers.
+
+"""
+
+import numpy as np
+import tensorflow as tf
+from tensorflow.keras import regularizers
+
+
+class InverseWishart(regularizers.Regularizer):
+    """Inverse Wishart regularizer.
+
+    Parameters
+    ----------
+    nu : int
+        Degrees of freedom. Must be greater than (n_channels - 1).
+    psi : np.ndarray
+        Scale matrix. All elements must be positive.
+        Shape must be (n_channels, n_channels).
+    """
+
+    def __init__(self, nu, psi, **kwargs):
+        super().__init__(**kwargs)
+        self.nu = nu
+        self.psi = psi
+        self.n_channels = psi.shape[-1]
+
+        if not self.nu > self.n_channels - 1:
+            raise ValueError("nu must be greater than (n_channels - 1).")
+
+        if np.any(self.psi < 0):
+            raise ValueError("psi must be positive.")
+
+    def __call__(self, cov):
+        log_det_cov = tf.reduce_sum(tf.linalg.logdet(cov))
+        inv_cov = tf.linalg.inv(cov)
+        reg = ((self.nu + self.n_channels + 1) / 2) * log_det_cov + tf.reduce_sum(
+            tf.multiply(
+                tf.linalg.diag_part(inv_cov),
+                tf.expand_dims(self.psi, axis=0),
+            )
+        ) / 2
+        return reg
+
+
+class MultivariateNormal(regularizers.Regularizer):
+    """Multivariate normal regularizer.
+
+    Parameters
+    ----------
+    sigma : np.ndarray
+        1D numpy array of variances for each channel.
+        Shape must be (n_channels,).
+    """
+
+    def __init__(self, sigma, **kwargs):
+        super().__init__(**kwargs)
+        self.sigma = sigma
+        self.regularization_strength = 1 / (2 * sigma)
+
+    def __call__(self, vectors):
+        reg = tf.reduce_sum(
+            tf.multiply(
+                tf.math.square(vectors),
+                tf.expand_dims(self.regularization_strength, axis=0),
+            )
+        )
+        return reg

--- a/osl_dynamics/inference/regularizers.py
+++ b/osl_dynamics/inference/regularizers.py
@@ -15,7 +15,7 @@ class InverseWishart(regularizers.Regularizer):
     nu : int
         Degrees of freedom. Must be greater than (n_channels - 1).
     psi : np.ndarray
-        Scale matrix. All elements must be positive.
+        Scale matrix. Must be a symmetric positive definite matrix.
         Shape must be (n_channels, n_channels).
     """
 
@@ -25,21 +25,30 @@ class InverseWishart(regularizers.Regularizer):
         self.psi = psi
         self.n_channels = psi.shape[-1]
 
+        # Validation
         if not self.nu > self.n_channels - 1:
             raise ValueError("nu must be greater than (n_channels - 1).")
 
-        if np.any(self.psi < 0):
-            raise ValueError("psi must be positive.")
+        if self.psi.ndim != 2:
+            raise ValueError("psi must be a 2D array.")
+
+        if not np.allclose(self.psi, self.psi.T):
+            raise ValueError("psi must be symmetric.")
+
+        try:
+            np.linalg.cholesky(self.psi)
+        except:
+            raise ValueError(
+                "Cholesky decomposition of psi failed. psi must be positive definite."
+            )
 
     def __call__(self, cov):
-        log_det_cov = tf.reduce_sum(tf.linalg.logdet(cov))
+        log_det_cov = tf.linalg.logdet(cov)
         inv_cov = tf.linalg.inv(cov)
-        reg = ((self.nu + self.n_channels + 1) / 2) * log_det_cov + tf.reduce_sum(
-            tf.multiply(
-                tf.linalg.diag_part(inv_cov),
-                tf.expand_dims(self.psi, axis=0),
-            )
-        ) / 2
+        reg = tf.reduce_sum(
+            ((self.nu + self.n_channels + 1) / 2) * log_det_cov
+            + (1 / 2) * tf.linalg.trace(tf.matmul(tf.expand_dims(self.psi, 0), inv_cov))
+        )
         return reg
 
 
@@ -48,21 +57,47 @@ class MultivariateNormal(regularizers.Regularizer):
 
     Parameters
     ----------
-    sigma : np.ndarray
-        1D numpy array of variances for each channel.
+    mu : np.ndarray
+        1D numpy array of the mean of the prior.
         Shape must be (n_channels,).
+    sigma : np.ndarray
+        2D numpy array of covariance matrix of the prior.
+        Shape must be (n_channels, n_channels).
     """
 
-    def __init__(self, sigma, **kwargs):
+    def __init__(self, mu, sigma, **kwargs):
         super().__init__(**kwargs)
+        self.mu = mu
         self.sigma = sigma
-        self.regularization_strength = 1 / (2 * sigma)
+
+        # Validation
+        if self.mu.ndim != 1:
+            raise ValueError("mu must be a 1D array.")
+
+        if self.sigma.ndim != 2:
+            raise ValueError("sigma must be a 2D array.")
+
+        if not np.allclose(self.sigma, self.sigma.T):
+            raise ValueError("sigma must be symmetric.")
+
+        try:
+            np.linalg.cholesky(self.sigma)
+        except:
+            raise ValueError(
+                "Cholesky decomposition of sigma failed. sigma must be positive definite."
+            )
+
+        self.inv_sigma = tf.linalg.inv(self.sigma)
 
     def __call__(self, vectors):
-        reg = tf.reduce_sum(
-            tf.multiply(
-                tf.math.square(vectors),
-                tf.expand_dims(self.regularization_strength, axis=0),
+        vectors = vectors - tf.expand_dims(self.mu, 0)
+
+        reg = (1 / 2) * tf.reduce_sum(
+            tf.matmul(
+                tf.expand_dims(vectors, -2),
+                tf.matmul(
+                    tf.expand_dims(self.inv_sigma, 0), tf.expand_dims(vectors, -1)
+                ),
             )
         )
         return reg

--- a/osl_dynamics/models/dynemo.py
+++ b/osl_dynamics/models/dynemo.py
@@ -16,6 +16,7 @@ from osl_dynamics.models.inf_mod_base import (
     VariationalInferenceModelConfig,
     VariationalInferenceModelBase,
 )
+from osl_dynamics.inference import regularizers
 from osl_dynamics.inference.layers import (
     InferenceRNNLayer,
     LogLikelihoodLossLayer,
@@ -218,6 +219,72 @@ class Model(VariationalInferenceModelBase):
             the model?
         """
         dynemo_obs.set_covariances(self.model, covariances, update_initializer)
+
+    def set_means_regularizer(self, training_data=None, sigma=None):
+        """Set the means vector regularizer.
+
+        The regularization is equivalent to applying a multivariate normal prior.
+
+        Parameters
+        ----------
+        training_data : osl_dynamics.data.Data
+            Estimate sigma using the training data instead of specifying it
+            explicitly. If training_data is passed, sigma=(max - min / 2)**2.
+        sigma : np.ndarray
+            Variance of each channel. Shape must be (n_channels,).
+        """
+        if training_data is None and sigma is None:
+            raise ValueError("Either sigma or training_data must be passed.")
+
+        if training_data is not None:
+            ts = training_data.time_series(concatenate=True)
+            range_ = np.amax(ts, axis=0) - np.amin(ts, axis=0)
+            sigma = (range_ / 2) ** 2
+
+        means_layer = self.model.get_layer("means")
+        means_layer.regularizer = regularizers.MultivariateNormal(sigma)
+
+    def set_covariances_regularizer(self, training_data=None, nu=None, psi=None):
+        """Set the covariance matrices regularizer.
+
+        Parameters
+        ----------
+        training_data : osl_dynamics.data.Data
+            Estimate nu and psi using the training data instead of specifying it
+            explicitly. If training_data is passed, nu=n_channels - 1 + 0.1
+            and psi=1 / (max - min)
+        nu : int
+            Degrees of freedom.
+        psi : np.ndarray
+            Scale matrix. Shape must be (n_channels, n_channels).
+        """
+        if training_data is None:
+            if nu is None or psi is None:
+                raise ValueError("Both nu and psi must be passed.")
+
+        if training_data is not None:
+            nu = self.config.n_channels - 1 + 0.1
+            ts = training_data.time_series(concatenate=True)
+            range_ = np.amax(ts, axis=0) - np.amin(ts, axis=0)
+            psi = 1 / range_
+
+        covs_layer = self.model.get_layer("covs")
+        covs_layer.regularizer = regularizers.InverseWishart(nu, psi)
+
+    def set_means_covariances_regularizer(self, training_data):
+        """Set the means and covariances regularizer based on the training data.
+
+        A multivariate normal prior is applied to the mean vectors with
+        sigma=(range / 2)**2 and an inverse Wishart prior is applied to the
+        covariances matrices with nu=n_channels - 1 + 0.1 and psi=1 / range.
+
+        Parameters
+        ----------
+        training_data : osl_dynamics.data.Data
+            Training dataset.
+        """
+        self.set_means_regularizer(training_data)
+        self.set_covariances_regularizer(training_data)
 
     def sample_alpha(self, n_samples, theta_norm=None):
         """Uses the model RNN to sample mode mixing factors, alpha.


### PR DESCRIPTION
Added regularisation options to the means, covariances layers.
Allowed DyNeMo to have covariances, means regularised.
Still need work on other models that depend on these two layers.
Also allowed connectivity.save() to save maps with no non-zero connections.