### PR TITLE
Improved initialisation of observation model parameters.

### DIFF
--- a/examples/simulation/dynemo_hmm-mvn_high-n-modes.py
+++ b/examples/simulation/dynemo_hmm-mvn_high-n-modes.py
@@ -1,0 +1,87 @@
+"""Example script for running DyNeMo on simulated HMM-MVN data with
+a large number of states.
+
+"""
+
+print("Setting up")
+from osl_dynamics import data, simulation
+from osl_dynamics.inference import metrics, modes, tf_ops
+from osl_dynamics.models.dynemo import Config, Model
+
+# GPU settings
+tf_ops.gpu_growth()
+
+# Settings
+config = Config(
+    n_modes=12,
+    n_channels=80,
+    sequence_length=100,
+    inference_n_units=64,
+    inference_normalization="layer",
+    model_n_units=64,
+    model_normalization="layer",
+    learn_alpha_temperature=True,
+    initial_alpha_temperature=1.0,
+    learn_means=False,
+    learn_covariances=True,
+    do_kl_annealing=True,
+    kl_annealing_curve="tanh",
+    kl_annealing_sharpness=10,
+    n_kl_annealing_epochs=50,
+    batch_size=16,
+    learning_rate=0.01,
+    n_epochs=100,
+)
+
+# Simulate data
+print("Simulating data")
+sim = simulation.HMM_MVN(
+    n_samples=25600,
+    n_modes=config.n_modes,
+    n_channels=config.n_channels,
+    trans_prob="sequence",
+    stay_prob=0.9,
+    means="zero",
+    covariances="random",
+    random_seed=123,
+)
+sim.standardize()
+training_data = data.Data(sim.time_series)
+
+# Build model
+model = Model(config)
+model.summary()
+
+# Initialization
+init_history = model.random_subset_initialization(
+    training_data,
+    n_epochs=20,
+    n_init=5,
+    take=0.25,
+)
+
+print("Training model")
+history = model.fit(training_data)
+
+# Free energy = Log Likelihood - KL Divergence
+free_energy = model.free_energy(training_data)
+print(f"Free energy: {free_energy}")
+
+# Inferred mode mixing factors and state time course
+inf_alp = model.get_alpha(training_data)
+inf_stc = modes.argmax_time_courses(inf_alp)
+sim_stc = sim.mode_time_course
+
+# Inferred covariances
+inf_cov = model.get_covariances()
+sim_cov = sim.covariances
+
+# Reorder inferred modes to match the simulation
+_, order = modes.match_modes(sim_stc, inf_stc, return_order=True)
+inf_stc = inf_stc[:, order]
+inf_cov = inf_cov[order]
+
+# Metrics
+print("Dice coefficient:", metrics.dice_coefficient(sim_stc, inf_stc))
+print("Fractional occupancies (Simulation):", modes.fractional_occupancies(sim_stc))
+print("Fractional occupancies (DyNeMo):", modes.fractional_occupancies(inf_stc))

--- a/examples/simulation/mdynemo_hmm-mvn.py
+++ b/examples/simulation/mdynemo_hmm-mvn.py
@@ -16,10 +16,10 @@ tf_ops.gpu_growth()
 config = Config(
     n_modes=5,
     n_channels=20,
-    sequence_length=200,
-    inference_n_units=256,
+    sequence_length=100,
+    inference_n_units=128,
     inference_normalization="layer",
-    model_n_units=256,
+    model_n_units=128,
     model_normalization="layer",
     theta_normalization="layer",
     learn_alpha_temperature=True,
@@ -30,10 +30,10 @@ config = Config(
     do_kl_annealing=True,
     kl_annealing_curve="tanh",
     kl_annealing_sharpness=10,
-    n_kl_annealing_epochs=200,
+    n_kl_annealing_epochs=100,
     batch_size=16,
-    learning_rate=0.001,
-    n_epochs=400,
+    learning_rate=0.01,
+    n_epochs=200,
 )
 
 # Simulate data
@@ -59,11 +59,7 @@ model.summary()
 model.set_regularizers(training_data)
 
 print("Training model")
-history = model.fit(
-    training_data,
-    save_best_after=config.n_kl_annealing_epochs,
-    save_filepath="tmp/weights",
-)
+history = model.fit(training_data)
 
 # Free energy = Log Likelihood - KL Divergence
 free_energy = model.free_energy(training_data)
@@ -101,6 +97,3 @@ print("Fractional occupancies mean (DyNeMo):", fo_inf_alpha)
 
 print("Fractional occupancies fc (Simulation):", fo_sim_gamma)
 print("Fractional occupancies fc (DyNeMo):", fo_inf_gamma)
-
-# Delete temporary directory
-training_data.delete_dir()

--- a/examples/simulation/sedynemo_hmm-mvn.py
+++ b/examples/simulation/sedynemo_hmm-mvn.py
@@ -18,13 +18,13 @@ tf_ops.gpu_growth()
 config = Config(
     n_modes=5,
     n_channels=20,
-    n_subjects=20,
+    n_subjects=10,
     subject_embedding_dim=5,
     mode_embedding_dim=2,
-    sequence_length=200,
-    inference_n_units=128,
+    sequence_length=100,
+    inference_n_units=64,
     inference_normalization="layer",
-    model_n_units=128,
+    model_n_units=64,
     model_normalization="layer",
     learn_alpha_temperature=True,
     initial_alpha_temperature=1.0,
@@ -33,10 +33,10 @@ config = Config(
     do_kl_annealing=True,
     kl_annealing_curve="tanh",
     kl_annealing_sharpness=10,
-    n_kl_annealing_epochs=100,
-    batch_size=64,
-    learning_rate=0.005,
-    n_epochs=200,
+    n_kl_annealing_epochs=50,
+    batch_size=128,
+    learning_rate=0.01,
+    n_epochs=100,
     multi_gpu=False,
 )
 
@@ -44,7 +44,7 @@ config = Config(
 print("Simulating data")
 
 sim = simulation.MSubj_HMM_MVN(
-    n_samples=12800,
+    n_samples=25600,
     n_subjects=config.n_subjects,
     n_modes=config.n_modes,
     n_channels=config.n_channels,

--- a/osl_dynamics/inference/initializers.py
+++ b/osl_dynamics/inference/initializers.py
@@ -30,10 +30,7 @@ class WeightInitializer(Initializer):
 
 
 class IdentityCholeskyInitializer(Initializer):
-    """Initialize weights to a flattened cholesky factor of identity
-    matrices with a normal error added to the diagonal.
-
-    """
+    """Initialize weights to a flattened cholesky factor of identity matrices."""
 
     def __init__(*args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -79,7 +76,7 @@ class NormalIdentityCholeskyInitializer(Initializer):
 
 class NormalCorrelationCholeskyInitializer(Initializer):
     """Initialize weights to a flattened cholesky factor of correlation
-    matrices with an error added.
+    matrices with a normal error added to the flattened cholesky factor.
 
     Parameters
     ----------
@@ -112,7 +109,7 @@ class NormalCorrelationCholeskyInitializer(Initializer):
 
 
 class NormalDiagonalInitializer(Initializer):
-    """Initializer for diagonal matrices with an error added.
+    """Initializer for diagonal matrices with a normal error added.
 
     Parameters
     ----------

--- a/osl_dynamics/inference/initializers.py
+++ b/osl_dynamics/inference/initializers.py
@@ -2,9 +2,13 @@
 
 """
 
+import numpy as np
+import tensorflow_probability as tfp
 from tensorflow.keras import Model, layers
 from tensorflow.keras.initializers import Initializer
 from osl_dynamics import inference
+
+tfb = tfp.bijectors
 
 
 class WeightInitializer(Initializer):
@@ -17,11 +21,120 @@ class WeightInitializer(Initializer):
         Note, the shape is not checked.
     """
 
-    def __init__(self, initial_value):
+    def __init__(self, initial_value, **kwargs):
+        super().__init__(**kwargs)
         self.initial_value = initial_value
 
     def __call__(self, shape, dtype=None):
         return self.initial_value
+
+
+class IdentityCholeskyInitializer(Initializer):
+    """Initialize weights to a flattened cholesky factor of identity
+    matrices with a normal error added to the diagonal.
+
+    """
+
+    def __init__(*args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Bijector used to transform learnable vectors to covariance matrices
+        self.bijector = tfb.Chain([tfb.CholeskyOuterProduct(), tfb.FillScaleTriL()])
+
+    def __call__(self, shape, dtype=None):
+        n = shape[0]  # n_modes
+        m = int(np.sqrt(1 + 8 * shape[1]) / 2 - 0.5)  # n_channels
+        diagonals = np.ones([n, m])
+        matrices = np.array([np.diag(d) for d in diagonals], dtype=np.float32)
+        return self.bijector.inverse(matrices)
+
+
+class NormalIdentityCholeskyInitializer(Initializer):
+    """Initialize weights to a flattened cholesky factor of identity
+    matrices with a normal error added to the diagonal.
+
+    Parameters
+    ----------
+    mean : float
+        Mean of the error to add.
+    std : float
+        Standard deviation of the error to add.
+    """
+
+    def __init__(self, mean, std, **kwargs):
+        super().__init__(**kwargs)
+        self.mean = mean
+        self.std = std
+
+        # Bijector used to transform learnable vectors to covariance matrices
+        self.bijector = tfb.Chain([tfb.CholeskyOuterProduct(), tfb.FillScaleTriL()])
+
+    def __call__(self, shape, dtype=None):
+        n = shape[0]  # n_modes
+        m = int(np.sqrt(1 + 8 * shape[1]) / 2 - 0.5)  # n_channels
+        diagonals = np.random.normal(self.mean + 1, self.std, size=[n, m])
+        matrices = np.array([np.diag(d) for d in diagonals], dtype=np.float32)
+        return self.bijector.inverse(matrices)
+
+
+class NormalCorrelationCholeskyInitializer(Initializer):
+    """Initialize weights to a flattened cholesky factor of correlation
+    matrices with an error added.
+
+    Parameters
+    ----------
+    mean : float
+        Mean of the error to add.
+    std : float
+        Standard deviation of the error to add.
+    """
+
+    def __init__(self, mean, std, **kwargs):
+        super().__init__(**kwargs)
+        self.mean = mean
+        self.std = std
+
+        # Bijector used to transform learnable vectors to covariance matrices
+        self.bijector = tfb.Chain(
+            [tfb.CholeskyOuterProduct(), tfb.CorrelationCholesky()]
+        )
+
+    def __call__(self, shape, dtype=None):
+        n = shape[0]  # n_modes
+        m = int(np.sqrt(1 + 8 * shape[1]) / 2 + 0.5)  # n_channels
+        diagonals = np.ones([n, m])
+        matrices = np.array([np.diag(d) for d in diagonals], dtype=np.float32)
+        cholesky_factors = self.bijector.inverse(matrices)
+        cholesky_factors += np.random.normal(
+            self.mean, self.std, size=cholesky_factors.shape
+        )
+        return cholesky_factors
+
+
+class NormalDiagonalInitializer(Initializer):
+    """Initializer for diagonal matrices with an error added.
+
+    Parameters
+    ----------
+    mean : float
+        Mean of the error to add.
+    std : float
+        Standard deviation of the error to add.
+    """
+
+    def __init__(self, mean, std, **kwargs):
+        super().__init__(**kwargs)
+        self.mean = mean
+        self.std = std
+
+        # Softplus transformation to ensure diagonal is positive
+        self.bijector = tfb.Softplus()
+
+    def __call__(self, shape, dtype=None):
+        n = shape[0]  # n_modes
+        m = shape[1]  # n_channels
+        diagonals = np.random.normal(1, 0.05, size=[n, m]).astype(np.float32)
+        return self.bijector.inverse(diagonals)
 
 
 class CopyTensorInitializer(Initializer):

--- a/osl_dynamics/inference/layers.py
+++ b/osl_dynamics/inference/layers.py
@@ -5,8 +5,9 @@
 import numpy as np
 import tensorflow as tf
 import tensorflow_probability as tfp
-from tensorflow.keras import activations, layers
-from osl_dynamics.inference.initializers import WeightInitializer
+from tensorflow.keras import activations, layers, initializers
+
+import osl_dynamics.inference.initializers as osld_initializers
 
 tfb = tfp.bijectors
 
@@ -193,7 +194,9 @@ class SoftmaxLayer(layers.Layer):
         super().__init__(**kwargs)
         self.initial_temperature = initial_temperature
         self.learn_temperature = learn_temperature
-        self.temperature_initializer = WeightInitializer(self.initial_temperature)
+        self.temperature_initializer = osld_initializers.WeightInitializer(
+            self.initial_temperature
+        )
 
     def build(self, input_shape):
         self.temperature = self.add_weight(
@@ -232,7 +235,9 @@ class ScalarLayer(layers.Layer):
             self.initial_value = 1
         else:
             self.initial_value = initial_value
-        self.scalar_initializer = WeightInitializer(self.initial_value)
+        self.scalar_initializer = osld_initializers.WeightInitializer(
+            self.initial_value
+        )
 
     def build(self, input_shape):
         self.scalar = self.add_weight(
@@ -280,14 +285,8 @@ class MeanVectorsLayer(layers.Layer):
         self.m = m
         self.learn = learn
 
-        # Initialisation for vectors
-        if initial_value is None:
-            if learn:
-                self.initial_value = np.random.normal(0, 0.02, size=[n, m])
-            else:
-                self.initial_value = np.zeros([n, m])
-            self.initial_value = self.initial_value.astype(np.float32)
-        else:
+        if initial_value is not None:
+            # Use value passed to initialise
             if initial_value.ndim != 2:
                 raise ValueError(
                     "a (n_modes, n_channels) array must be passed for initial_means."
@@ -302,8 +301,17 @@ class MeanVectorsLayer(layers.Layer):
                     "mismatch bettwen the number of modes and vectors in "
                     + f"initial_means ({initial_value.shape[0]})."
                 )
-            self.initial_value = initial_value.astype("float32")
-        self.vectors_initializer = WeightInitializer(self.initial_value)
+            initial_value = initial_value.astype("float32")
+            self.vectors_initializer = osld_initializers.WeightInitializer(
+                initial_value
+            )
+
+        elif learn:
+            # Use a random vector to initialise
+            self.vectors_initializer = initializers.TruncatedNormal(0, 0.02)
+        else:
+            # We're not learning the mean vectors, use zeros
+            self.vectors_initializer = initializers.Zeros()
 
         # Regulariser
         self.regularizer = regularizer
@@ -371,16 +379,8 @@ class CovarianceMatricesLayer(layers.Layer):
         # Bijector used to transform learnable vectors to covariance matrices
         self.bijector = tfb.Chain([tfb.CholeskyOuterProduct(), tfb.FillScaleTriL()])
 
-        # Initialisation of matrices
-        if initial_value is None:
-            if learn:
-                self.initial_value = np.array(
-                    [np.diag(np.random.normal(1, 0.05, size=m)) for i in range(n)]
-                )
-            else:
-                self.initial_value = np.array([np.eye(m)] * n)
-            self.initial_value = self.initial_value.astype(np.float32)
-        else:
+        if initial_value is not None:
+            # Used passed value to initialise
             if initial_value.ndim != 3:
                 raise ValueError(
                     "a (n_modes, n_channels, n_channels) array must be passed for "
@@ -397,13 +397,23 @@ class CovarianceMatricesLayer(layers.Layer):
                     "mismatch bettwen the number of modes and matrices in "
                     + f"initial_covariances ({initial_value.shape[0]})."
                 )
-            self.initial_value = initial_value.astype("float32")
-        self.initial_flattened_cholesky_factors = self.bijector.inverse(
-            self.initial_value
-        )
-        self.flattened_cholesky_factors_initializer = WeightInitializer(
-            self.initial_flattened_cholesky_factors
-        )
+            initial_value = initial_value.astype("float32")
+            initial_flattened_cholesky_factors = self.bijector.inverse(initial_value)
+            self.flattened_cholesky_factors_initializer = (
+                osld_initializers.WeightInitializer(initial_flattened_cholesky_factors)
+            )
+
+        elif learn:
+            # Use the identity matrix with a random error
+            self.flattened_cholesky_factors_initializer = (
+                osld_initializers.NormalIdentityCholeskyInitializer(mean=0, std=0.1)
+            )
+
+        else:
+            # Use the identity matrix
+            self.flattened_cholesky_factors_initializer = (
+                osld_initializers.IdentityCholeskyInitializer()
+            )
 
         # Regulariser
         self.regularizer = regularizer
@@ -473,18 +483,8 @@ class CorrelationMatricesLayer(layers.Layer):
             [tfb.CholeskyOuterProduct(), tfb.CorrelationCholesky()]
         )
 
-        # Initialisation of matrices
-        if initial_value is None:
-            self.initial_value = np.stack([np.eye(m, dtype=np.float32)] * n)
-            self.initial_flattened_cholesky_factors = self.bijector.inverse(
-                self.initial_value
-            )
-            if learn:
-                err = np.random.normal(
-                    0, 0.05, size=self.initial_flattened_cholesky_factors.shape
-                )
-                self.initial_flattened_cholesky_factors += err
-        else:
+        if initial_value is not None:
+            # Use passed value for initialisation
             if initial_value.ndim != 3:
                 raise ValueError(
                     "a (n_modes, n_channels, n_channels) array must be passed for "
@@ -501,13 +501,23 @@ class CorrelationMatricesLayer(layers.Layer):
                     "mismatch bettwen the number of modes and matrices in "
                     + f"initial_fcs ({initial_value.shape[0]})."
                 )
-            self.initial_value = initial_value.astype("float32")
-            self.initial_flattened_cholesky_factors = self.bijector.inverse(
-                self.initial_value
+            initial_value = initial_value.astype("float32")
+            initial_flattened_cholesky_factors = self.bijector.inverse(initial_value)
+            self.flattened_cholesky_factors_initializer = (
+                osld_initializers.WeightInitializer(initial_flattened_cholesky_factors)
             )
-        self.flattened_cholesky_factors_initializer = WeightInitializer(
-            self.initial_flattened_cholesky_factors
-        )
+
+        elif learn:
+            # Use a correlation matrix with an error added
+            self.flattened_cholesky_factors_initializer = (
+                osld_initializers.NormalCorrelationCholeskyInitializer(mean=0, std=0.1)
+            )
+
+        else:
+            # Use an identity matrix
+            self.flattened_cholesky_factors_initializer = (
+                osld_initializers.IdentityCholeskyInitializer()
+            )
 
         # Regulariser
         self.regularizer = regularizer
@@ -574,14 +584,8 @@ class DiagonalMatricesLayer(layers.Layer):
         # Softplus transformation to ensure diagonal is positive
         self.bijector = tfb.Softplus()
 
-        # Initialisation for the diagonals
-        if initial_value is None:
-            if learn:
-                self.initial_value = np.random.normal(1, 0.1, size=[n, m])
-            else:
-                self.initial_value = np.zeros([n, m])
-            self.initial_value = self.initial_value.astype(np.float32)
-        else:
+        if initial_value is not None:
+            # Used passed value for initialisation
             if initial_value.ndim != 2:
                 raise ValueError(
                     "a (n_modes, n_channels) array must be passed for initial_value."
@@ -596,9 +600,25 @@ class DiagonalMatricesLayer(layers.Layer):
                     "mismatch bettwen the number of modes and vectors in "
                     + f"initial_value ({initial_value.shape[0]})."
                 )
-            self.initial_value = initial_value.astype("float32")
-        self.initial_diagonals = self.bijector.inverse(self.initial_value)
-        self.diagonals_initializer = WeightInitializer(self.initial_diagonals)
+            initial_value = initial_value.astype("float32")
+            initial_diagonals = self.bijector.inverse(initial_value)
+            self.diagonals_initializer = osld_initializers.WeightInitializer(
+                initial_diagonals
+            )
+
+        elif learn:
+            # Use random numbers
+            self.diagonals_initializer = osld_initializers.NormalDiagonalInitializer(
+                mean=0, std=0.05
+            )
+
+        else:
+            # Use ones
+            initial_value = np.ones(size=[n, m]).astype(np.float32)
+            initial_diagonals = self.bijector.inverse(initial_value)
+            self.diagonals_initializer = osld_initializers.WeightInitializer(
+                initial_diagonals
+            )
 
         # Regulariser
         self.regularizer = regularizer
@@ -652,7 +672,6 @@ class MatrixLayer(layers.Layer):
         self.constraint = constraint
         self.learn = learn
 
-        self.initial_value = initial_value
         if initial_value is not None:
             if initial_value.shape[-1] != m:
                 raise ValueError(

--- a/osl_dynamics/models/dynemo_obs.py
+++ b/osl_dynamics/models/dynemo_obs.py
@@ -11,6 +11,7 @@ from tensorflow.keras import layers
 import osl_dynamics.data.tf as dtf
 from osl_dynamics.models.mod_base import BaseModelConfig, ModelBase
 from osl_dynamics.inference import regularizers
+from osl_dynamics.inference.initializers import WeightInitializer
 from osl_dynamics.inference.layers import (
     LogLikelihoodLossLayer,
     MeanVectorsLayer,
@@ -225,8 +226,7 @@ def set_means(model, means, update_initializer=True):
     layer_weights.assign(means)
 
     if update_initializer:
-        means_layer.initial_value = means
-        means_layer.vectors_initializer.initial_value = means
+        means_layer.vectors_initializer = WeightInitializer(means)
 
 
 def set_covariances(model, covariances, update_initializer=True):
@@ -237,9 +237,7 @@ def set_covariances(model, covariances, update_initializer=True):
     layer_weights.assign(flattened_cholesky_factors)
 
     if update_initializer:
-        covs_layer.initial_value = covariances
-        covs_layer.initial_flattened_cholesky_factors = flattened_cholesky_factors
-        covs_layer.flattened_cholesky_factors_initializer.initial_value = (
+        covs_layer.flattened_cholesky_factors_initializer = WeightInitializer(
             flattened_cholesky_factors
         )
 

--- a/osl_dynamics/models/dynemo_obs.py
+++ b/osl_dynamics/models/dynemo_obs.py
@@ -122,7 +122,7 @@ class Model(ModelBase):
         Parameters
         ----------
         means : np.ndarray
-            Mode covariances.
+            Mode means.
         update_initializer : bool
             Do we want to use the passed means when we re-initialize
             the model?
@@ -219,9 +219,9 @@ def get_means_covariances(model):
     return means, covs
 
 
-def set_means(model, means, update_initializer=True):
+def set_means(model, means, update_initializer=True, layer_name="means"):
     means = means.astype(np.float32)
-    means_layer = model.get_layer("means")
+    means_layer = model.get_layer(layer_name)
     layer_weights = means_layer.vectors
     layer_weights.assign(means)
 
@@ -229,9 +229,9 @@ def set_means(model, means, update_initializer=True):
         means_layer.vectors_initializer = WeightInitializer(means)
 
 
-def set_covariances(model, covariances, update_initializer=True):
+def set_covariances(model, covariances, update_initializer=True, layer_name="covs"):
     covariances = covariances.astype(np.float32)
-    covs_layer = model.get_layer("covs")
+    covs_layer = model.get_layer(layer_name)
     layer_weights = covs_layer.flattened_cholesky_factors
     flattened_cholesky_factors = covs_layer.bijector.inverse(covariances)
     layer_weights.assign(flattened_cholesky_factors)

--- a/osl_dynamics/models/mdynemo.py
+++ b/osl_dynamics/models/mdynemo.py
@@ -214,7 +214,7 @@ class Model(VariationalInferenceModelBase):
 
     def get_observation_model_parameters(self):
         """Wrapper for get_means_stds_fcs."""
-        return get_means_stds_fcs()
+        return self.get_means_stds_fcs()
 
     def set_means_stds_fcs(self, means, stds, fcs, update_initializer=True):
         """Set the means, standard deviations, functional connectivities of each mode.

--- a/osl_dynamics/models/mdynemo.py
+++ b/osl_dynamics/models/mdynemo.py
@@ -212,6 +212,10 @@ class Model(VariationalInferenceModelBase):
         """
         return mdynemo_obs.get_means_stds_fcs(self.model)
 
+    def get_observation_model_parameters(self):
+        """Wrapper for get_means_stds_fcs."""
+        return get_means_stds_fcs()
+
     def set_means_stds_fcs(self, means, stds, fcs, update_initializer=True):
         """Set the means, standard deviations, functional connectivities of each mode.
 
@@ -229,6 +233,17 @@ class Model(VariationalInferenceModelBase):
             the model?
         """
         mdynemo_obs.set_means_stds_fcs(self.model, means, stds, fcs, update_initializer)
+
+    def set_observation_model_parameters(
+        self, observation_model_parameters, update_initializer=True
+    ):
+        """Wrapper for set_means_stds_fcs."""
+        self.set_means_stds_fcs(
+            observation_model_parameters[0],
+            observation_model_parameters[1],
+            observation_model_parameters[2],
+            update_initializer=update_initializer,
+        )
 
     def set_regularizers(self, training_dataset):
         """Set the regularizers of means, stds and fcs based on the training data.

--- a/osl_dynamics/models/mdynemo_obs.py
+++ b/osl_dynamics/models/mdynemo_obs.py
@@ -12,6 +12,7 @@ import osl_dynamics.data.tf as dtf
 from osl_dynamics.models.mod_base import BaseModelConfig, ModelBase
 from osl_dynamics.models import dynemo_obs
 from osl_dynamics.inference import regularizers
+from osl_dynamics.inference.initializers import WeightInitializer
 from osl_dynamics.inference.layers import (
     LogLikelihoodLossLayer,
     MeanVectorsLayer,
@@ -255,16 +256,9 @@ def set_means_stds_fcs(model, means, stds, fcs, update_initializer=True):
 
     # Update initialisers
     if update_initializer:
-        means_layer.initial_value = means
-        stds_layer.initial_value = stds
-        fcs_layer.initial_value = fcs
-
-        stds_layer.initial_diagonals = diagonals
-        fcs_layer.initial_flattened_cholesky_factors = flattened_cholesky_factors
-
-        means_layer.vectors_initializer.initial_value = means
-        stds_layer.diagonals_initializer.initial_value = diagonals
-        fcs_layer.flattened_cholesky_factors_initializer.initial_value = (
+        means_layer.vectors_initializer = WeightInitializer(means)
+        stds_layer.diagonals_initializer = WeightInitializer(diagonals)
+        fcs_layer.flattened_cholesky_factors_initializer = WeightInitializer(
             flattened_cholesky_factors
         )
 

--- a/osl_dynamics/models/mod_base.py
+++ b/osl_dynamics/models/mod_base.py
@@ -250,7 +250,7 @@ class ModelBase:
         self.reset_weights()
         self.compile()
 
-    def make_dataset(self, inputs, shuffle=False, concatenate=False):
+    def make_dataset(self, inputs, shuffle=False, concatenate=False, subj_id=False):
         """Converts a Data object into a TensorFlow Dataset.
 
         Parameters
@@ -262,6 +262,8 @@ class ModelBase:
             Should we shuffle the data?
         concatenate : bool
             Should we return a single TensorFlow Dataset or a list of Datasets.
+        subj_id : bool
+            Should we include the subject id in the dataset?
 
         Returns
         -------
@@ -281,6 +283,7 @@ class ModelBase:
                 self.config.batch_size,
                 shuffle=shuffle,
                 concatenate=concatenate,
+                subj_id=subj_id,
             )
         elif isinstance(inputs, Dataset) and not concatenate:
             # Dataset -> list of Dataset if concatenate=False

--- a/osl_dynamics/models/sedynemo.py
+++ b/osl_dynamics/models/sedynemo.py
@@ -236,6 +236,10 @@ class Model(VariationalInferenceModelBase):
         """
         return sedynemo_obs.get_group_means_covariances(self.model)
 
+    def get_observation_model_parameters(self):
+        """Wrapper for get_group_means_covariances."""
+        return self.get_group_means_covariances()
+
     def get_subject_embeddings(self):
         """Get the subject embedding vectors
         Returns
@@ -319,6 +323,48 @@ class Model(VariationalInferenceModelBase):
             dynemo_obs.set_covariances_regularizer(
                 self.model, training_dataset, layer_name="group_covs"
             )
+
+    def set_group_means(self, group_means, update_initializer=True):
+        """Set the group means of each mode.
+
+        Parameters
+        ----------
+        group_means : np.ndarray
+            Mode means.
+        update_initializer : bool
+            Do we want to use the passed group means when we re-initialize the model?
+        """
+        dynemo_obs.set_means(
+            self.model, group_means, update_initializer, layer_name="group_means"
+        )
+
+    def set_group_covariances(self, group_covariances, update_initializer=True):
+        """Set the group covariances of each mode.
+
+        Parameters
+        ----------
+        group_covariances : np.ndarray
+            Mode covariances.
+        update_initializer : bool
+            Do we want to use the passed group covariances when we re-initialize
+            the model?
+        """
+        dynemo_obs.set_covariances(
+            self.model, group_covariances, update_initializer, layer_name="group_covs"
+        )
+
+    def set_observation_model_parameters(
+        self, observation_model_parameters, update_initializer=True
+    ):
+        """Wrapper for set_group_means and set_group_covariances."""
+        self.set_group_means(
+            observation_model_parameters[0],
+            update_initializer=update_initializer,
+        )
+        self.set_group_covariances(
+            observation_model_parameters[1],
+            update_initializer=update_initializer,
+        )
 
     def set_bayesian_kl_scaling(self, training_dataset):
         """Set the correct scaling for KL loss between deviation posterior and prior.

--- a/osl_dynamics/models/sedynemo.py
+++ b/osl_dynamics/models/sedynemo.py
@@ -221,6 +221,10 @@ class Model(VariationalInferenceModelBase):
         """Builds a keras model."""
         self.model = _model_structure(self.config)
 
+    def make_dataset(self, inputs, shuffle=False, concatenate=False, subj_id=True):
+        """SE-DyNeMo requires subject id to be included in the dataset."""
+        return super().make_dataset(inputs, shuffle, concatenate, subj_id)
+
     def get_group_means_covariances(self):
         """Get the group means and covariances of each mode
         Returns
@@ -317,7 +321,14 @@ class Model(VariationalInferenceModelBase):
             )
 
     def set_bayesian_kl_scaling(self, training_dataset):
-        """Set the correct scaling for KL loss between deviation posterior and prior."""
+        """Set the correct scaling for KL loss between deviation posterior and prior.
+
+        Parameters
+        ----------
+        training_dataset : tensorflow.data.Dataset or osl_dynamics.data.Data
+            Training dataset.
+        """
+        training_dataset = self.make_dataset(training_dataset, concatenate=True)
         n_batches = dtf.get_n_batches(training_dataset)
         learn_means = self.config.learn_means
         learn_covariances = self.config.learn_covariances

--- a/osl_dynamics/models/sedynemo.py
+++ b/osl_dynamics/models/sedynemo.py
@@ -336,6 +336,14 @@ class Model(VariationalInferenceModelBase):
             self.model, n_batches, learn_means, learn_covariances
         )
 
+    def random_subject_initialization(
+        self, training_data, n_epochs, n_subjects, n_kl_annealing_epochs=None, **kwargs
+    ):
+        """random subject initialisation not compatible with SE-DyNeMo."""
+        raise AttributeError(
+            " 'Model' object has no attribute 'random_subject_initialization'."
+        )
+
 
 def _model_structure(config):
     # layers for inputs

--- a/osl_dynamics/models/sedynemo_obs.py
+++ b/osl_dynamics/models/sedynemo_obs.py
@@ -12,7 +12,6 @@ from tensorflow.keras import layers
 import osl_dynamics.data.tf as dtf
 from osl_dynamics.models import dynemo_obs
 from osl_dynamics.models.mod_base import BaseModelConfig, ModelBase
-from osl_dynamics.inference import regularizers
 from osl_dynamics.inference.layers import (
     DummyLayer,
     LogLikelihoodLossLayer,
@@ -248,6 +247,35 @@ class Model(ModelBase):
         learn_means = self.config.learn_means
         learn_covariances = self.config.learn_covariances
         set_bayesian_kl_scaling(self.model, n_batches, learn_means, learn_covariances)
+
+    def set_group_means(self, group_means, update_initializer=True):
+        """Set the group means of each mode.
+
+        Parameters
+        ----------
+        group_means : np.ndarray
+            Mode means.
+        update_initializer : bool
+            Do we want to use the passed group means when we re-initialize the model?
+        """
+        dynemo_obs.set_means(
+            self.model, group_means, update_initializer, layer_name="group_means"
+        )
+
+    def set_group_covariances(self, group_covariances, update_initializer=True):
+        """Set the group covariances of each mode.
+
+        Parameters
+        ----------
+        group_covariances : np.ndarray
+            Mode covariances.
+        update_initializer : bool
+            Do we want to use the passed group covariances when we re-initialize
+            the model?
+        """
+        dynemo_obs.set_covariances(
+            self.model, group_covariances, update_initializer, layer_name="group_covs"
+        )
 
 
 def _model_structure(config):


### PR DESCRIPTION
Changes:
- Rewrote the initialisation of TensorFlow weights to use new custom Initializer classes. This was done because we now add a random error to observation model parameters, therefore, when  we reinitialise the model we want to resample the error. Before you would always reset to the same random vector.
- Added new options for learning the initial mode means/covariances.
- Added an example with a high number of modes and channels. In this example a good initialisation is necessary to reliably achieve a high dice.