### PR TITLE
Fix/loading errors

### DIFF
--- a/osl_dynamics/models/mod_base.py
+++ b/osl_dynamics/models/mod_base.py
@@ -245,7 +245,7 @@ class ModelBase:
             Path to file containing model weights.
         """
         with self.config.strategy.scope():
-            self.model.load_weights(filepath)
+            return self.model.load_weights(filepath)
 
     def reset_weights(self):
         """Resets trainable variables in the model to their initial value."""

--- a/osl_dynamics/models/mod_base.py
+++ b/osl_dynamics/models/mod_base.py
@@ -430,6 +430,6 @@ class ModelBase:
         model = cls(config)
 
         # Restore weights
-        model.load_weights(f"{dirname}/weights")
+        model.load_weights(f"{dirname}/weights").expect_partial()
 
         return model


### PR DESCRIPTION
When saving weights, we include optimizer parameters. When loading them, we don't. This causes a slew of warning messages. By returning the status object from `load_weights`, we can call `.expect_partial` which suppresses these warnings.