### PR TITLE
Fix/spectra dimensions

### DIFF
--- a/osl_dynamics/analysis/spectral.py
+++ b/osl_dynamics/analysis/spectral.py
@@ -606,8 +606,11 @@ def multitaper_spectra(
     if isinstance(data, np.ndarray):
         if alpha.shape[0] != data.shape[0]:
             raise ValueError("data and alpha must have the same shape.")
-        data = [data]
-        alpha = [alpha]
+        
+        if data.ndim == 2:
+            data = [data]
+        if data.ndim == 2:
+            alpha = [alpha]
 
     if segment_length is None:
         segment_length = 2 * sampling_frequency

--- a/osl_dynamics/analysis/spectral.py
+++ b/osl_dynamics/analysis/spectral.py
@@ -760,9 +760,9 @@ def regression_spectra(
     Parameters
     ----------
     data : np.ndarray or list
-        Data to calculate a time-varying PSD for. Shape must be (n_samples, n_channels).
+        Data to calculate a time-varying PSD for. Shape must be ([n_subjects,] n_samples, n_channels).
     alpha : np.ndarray
-        Inferred mode mixing factors. Shape must be (n_samples, n_modes).
+        Inferred mode mixing factors. Shape must be ([n_subjects], n_samples, n_modes).
     window_length : int
         Number samples to use in the window to calculate a PSD.
     sampling_frequency : float
@@ -816,8 +816,11 @@ def regression_spectra(
             raise ValueError(
                 "data and alpha must both be lists or both be numpy arrays."
             )
-        data = [data]
-        alpha = [alpha]
+
+        if data.ndim == 2:
+            data = [data]
+        if alpha.ndim == 2:
+            alpha = [alpha]
 
     if frequency_range is None:
         frequency_range = [0, sampling_frequency / 2]


### PR DESCRIPTION
`regression_spectra` and `multitaper_spectra` were both adding a dimension to the `data` and `alphas` whenever `np.ndarray`s were passed. This was largely unproblematic because it's rare for all subjects to have the same `n_samples` so subjects would be passed in a list.

When treating channels as subjects, subject lengths are the same and can be passed as an array. This bug is fixed by checking that `ndim == 2` before wrapping the array in a list.