### PR TITLE
Standardisation

### DIFF
--- a/examples/simulation/mdynemo_hmm-mvn.py
+++ b/examples/simulation/mdynemo_hmm-mvn.py
@@ -8,6 +8,8 @@ print("Setting up")
 from osl_dynamics import data, simulation
 from osl_dynamics.inference import metrics, modes, tf_ops
 from osl_dynamics.models.mdynemo import Config, Model
+from osl_dynamics.utils import plotting
+import numpy as np
 
 # GPU settings
 tf_ops.gpu_growth()
@@ -74,9 +76,22 @@ inf_gamma = modes.argmax_time_courses(inf_gamma)
 # Simulated mode mixing factors
 sim_alpha, sim_gamma = sim.mode_time_course
 
+# Inferred means, stds, fcs
+inf_means, inf_stds, inf_fcs = model.get_means_stds_fcs()
+sim_means = sim.means
+sim_stds = sim.stds
+sim_fcs = sim.fcs
+
 # Match the inferred and simulated mixing factors
-sim_alpha, inf_alpha = modes.match_modes(sim_alpha, inf_alpha)
-sim_gamma, inf_gamma = modes.match_modes(sim_gamma, inf_gamma)
+_, order_alpha = modes.match_modes(sim_alpha, inf_alpha, return_order=True)
+_, order_gamma = modes.match_modes(sim_gamma, inf_gamma, return_order=True)
+
+inf_alpha = inf_alpha[:, order_alpha]
+inf_gamma = inf_gamma[:, order_gamma]
+
+inf_means = inf_means[order_alpha]
+inf_stds = np.array([np.diag(std) for std in inf_stds[order_alpha]])
+inf_fcs = inf_fcs[order_gamma]
 
 # Dice coefficients
 dice_alpha = metrics.dice_coefficient(sim_alpha, inf_alpha)
@@ -97,3 +112,48 @@ print("Fractional occupancies mean (DyNeMo):", fo_inf_alpha)
 
 print("Fractional occupancies fc (Simulation):", fo_sim_gamma)
 print("Fractional occupancies fc (DyNeMo):", fo_inf_gamma)
+
+# Plots
+plotting.plot_alpha(
+    sim_alpha,
+    n_samples=2000,
+    title="Ground truth " + r"$\alpha$",
+    y_labels=r"$\alpha_{jt}$",
+    filename="figures/sim_alpha.png",
+)
+plotting.plot_alpha(
+    inf_alpha,
+    n_samples=2000,
+    title="Inferred " + r"$\alpha$",
+    y_labels=r"$\alpha_{jt}$",
+    filename="figures/inf_alpha.png",
+)
+plotting.plot_alpha(
+    sim_gamma,
+    n_samples=2000,
+    title="Ground truth " + r"$\gamma$",
+    y_labels=r"$\gamma_{jt}$",
+    filename="figures/sim_gamma.png",
+)
+plotting.plot_alpha(
+    inf_gamma,
+    n_samples=2000,
+    title="Inferred " + r"$\gamma$",
+    y_labels=r"$\gamma_{jt}$",
+    filename="figures/inf_gamma.png",
+)
+plotting.plot_matrices(
+    sim_means, main_title="Ground Truth", filename="figures/sim_means.png"
+)
+plotting.plot_matrices(
+    inf_means, main_title="Inferred", filename="figures/inf_means.png"
+)
+
+plotting.plot_matrices(
+    sim_stds, main_title="Ground Truth", filename="figures/sim_stds.png"
+)
+plotting.plot_matrices(inf_stds, main_title="Inferred", filename="figures/inf_stds.png")
+plotting.plot_matrices(
+    sim_fcs, main_title="Ground Truth", filename="figures/sim_fcs.png"
+)
+plotting.plot_matrices(inf_fcs, main_title="Inferred", filename="figures/inf_fcs.png")

--- a/osl_dynamics/simulation/base.py
+++ b/osl_dynamics/simulation/base.py
@@ -34,6 +34,6 @@ class Simulation:
         return 1
 
     def standardize(self, axis=0):
-        mu = np.mean(self.time_series, axis=0)
-        sigma = np.std(self.time_series, axis=0)
+        mu = np.mean(self.time_series, axis=axis)
+        sigma = np.std(self.time_series, axis=axis)
         self.time_series = (self.time_series - mu) / sigma

--- a/osl_dynamics/simulation/hmm.py
+++ b/osl_dynamics/simulation/hmm.py
@@ -302,8 +302,12 @@ class HMM_MVN(Simulation):
             raise AttributeError(f"No attribute called {attr}.")
 
     def standardize(self):
+        means = np.mean(self.time_series, axis=0)
         standard_deviations = np.std(self.time_series, axis=0)
         super().standardize()
+        self.obs_mod.means = (
+            self.obs_mod.means - means[None, ...]
+        ) / standard_deviations[None, ...]
         self.obs_mod.covariances /= np.outer(standard_deviations, standard_deviations)[
             np.newaxis, ...
         ]
@@ -409,6 +413,15 @@ class MDyn_HMM_MVN(Simulation):
             return getattr(self.obs_mod, attr)
         else:
             raise AttributeError(f"No attribute called {attr}.")
+
+    def standardize(self):
+        means = np.mean(self.time_series, axis=0)
+        standard_deviations = np.std(self.time_series, axis=0)
+        super().standardize()
+        self.obs_mod.means = (
+            self.obs_mod.means - means[None, ...]
+        ) / standard_deviations[None, ...]
+        self.obs_mod.stds /= standard_deviations[None, ...]
 
 
 class MSubj_HMM_MVN(Simulation):
@@ -539,7 +552,15 @@ class MSubj_HMM_MVN(Simulation):
             raise AttributeError(f"No attribute called {attr}.")
 
     def standardize(self):
+        means = np.mean(self.time_series, axis=1)
+        standard_deviations = np.std(self.time_series, axis=1)
         super().standardize(axis=1)
+        self.obs_mod.means = (
+            self.obs_mod.means - means[:, None, :]
+        ) / standard_deviations[:, None, :]
+        self.obs_mod.subject_covariances /= np.expand_dims(
+            standard_deviations[:, :, None] @ standard_deviations[:, None, :], 1
+        )
 
 
 class HierarchicalHMM_MVN(Simulation):

--- a/osl_dynamics/simulation/sin.py
+++ b/osl_dynamics/simulation/sin.py
@@ -8,7 +8,7 @@ import numpy as np
 class SingleSine:
     """Class that generates sinusoidal time series data.
 
-    The time series for each channel is a singe single wave. The amplitude
+    The time series for each channel is a single single wave. The amplitude
     and frequency of the sine wave can be different for different states and
     channels. A random phase is used each time a state is activated.
 


### PR DESCRIPTION
Updated standardisation methods.

- Standardisation method applies to Multi-Dynamic HMM simulations and Multi-Subject simulations.
- Standardisation methods updates the simulated means, covs, stds, fcs accordingly.
- Updated mdynemo simulation example