### PR TITLE
Cleaned up initialisers

### DIFF
--- a/osl_dynamics/inference/initializers.py
+++ b/osl_dynamics/inference/initializers.py
@@ -21,8 +21,7 @@ class WeightInitializer(Initializer):
         Note, the shape is not checked.
     """
 
-    def __init__(self, initial_value, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, initial_value):
         self.initial_value = initial_value
 
     def __call__(self, shape, dtype=None):
@@ -32,9 +31,7 @@ class WeightInitializer(Initializer):
 class IdentityCholeskyInitializer(Initializer):
     """Initialize weights to a flattened cholesky factor of identity matrices."""
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
+    def __init__(self):
         # Bijector used to transform learnable vectors to covariance matrices
         self.bijector = tfb.Chain([tfb.CholeskyOuterProduct(), tfb.FillScaleTriL()])
 
@@ -52,15 +49,11 @@ class NormalIdentityCholeskyInitializer(Initializer):
 
     Parameters
     ----------
-    mean : float
-        Mean of the error to add.
     std : float
         Standard deviation of the error to add.
     """
 
-    def __init__(self, mean, std, **kwargs):
-        super().__init__(**kwargs)
-        self.mean = mean
+    def __init__(self, std):
         self.std = std
 
         # Bijector used to transform learnable vectors to covariance matrices
@@ -69,7 +62,7 @@ class NormalIdentityCholeskyInitializer(Initializer):
     def __call__(self, shape, dtype=None):
         n = shape[0]  # n_modes
         m = int(np.sqrt(1 + 8 * shape[1]) / 2 - 0.5)  # n_channels
-        diagonals = np.random.normal(self.mean + 1, self.std, size=[n, m])
+        diagonals = np.random.normal(1, self.std, size=[n, m])
         matrices = np.array([np.diag(d) for d in diagonals], dtype=np.float32)
         return self.bijector.inverse(matrices)
 
@@ -86,9 +79,7 @@ class NormalCorrelationCholeskyInitializer(Initializer):
         Standard deviation of the error to add.
     """
 
-    def __init__(self, mean, std, **kwargs):
-        super().__init__(**kwargs)
-        self.mean = mean
+    def __init__(self, std):
         self.std = std
 
         # Bijector used to transform learnable vectors to covariance matrices
@@ -102,9 +93,7 @@ class NormalCorrelationCholeskyInitializer(Initializer):
         diagonals = np.ones([n, m])
         matrices = np.array([np.diag(d) for d in diagonals], dtype=np.float32)
         cholesky_factors = self.bijector.inverse(matrices)
-        cholesky_factors += np.random.normal(
-            self.mean, self.std, size=cholesky_factors.shape
-        )
+        cholesky_factors += np.random.normal(0, self.std, size=cholesky_factors.shape)
         return cholesky_factors
 
 
@@ -113,15 +102,11 @@ class NormalDiagonalInitializer(Initializer):
 
     Parameters
     ----------
-    mean : float
-        Mean of the error to add.
     std : float
         Standard deviation of the error to add.
     """
 
-    def __init__(self, mean, std, **kwargs):
-        super().__init__(**kwargs)
-        self.mean = mean
+    def __init__(self, std):
         self.std = std
 
         # Softplus transformation to ensure diagonal is positive
@@ -130,7 +115,7 @@ class NormalDiagonalInitializer(Initializer):
     def __call__(self, shape, dtype=None):
         n = shape[0]  # n_modes
         m = shape[1]  # n_channels
-        diagonals = np.random.normal(1, 0.05, size=[n, m]).astype(np.float32)
+        diagonals = np.random.normal(1, self.std, size=[n, m]).astype(np.float32)
         return self.bijector.inverse(diagonals)
 
 

--- a/osl_dynamics/inference/layers.py
+++ b/osl_dynamics/inference/layers.py
@@ -452,7 +452,7 @@ class CovarianceMatricesLayer(layers.Layer):
         elif learn:
             # Use the identity matrix with a random error
             self.flattened_cholesky_factors_initializer = (
-                osld_initializers.NormalIdentityCholeskyInitializer(mean=0, std=0.1)
+                osld_initializers.NormalIdentityCholeskyInitializer(0.1)
             )
 
         else:
@@ -562,7 +562,7 @@ class CorrelationMatricesLayer(layers.Layer):
         elif learn:
             # Use a correlation matrix with an error added
             self.flattened_cholesky_factors_initializer = (
-                osld_initializers.NormalCorrelationCholeskyInitializer(mean=0, std=0.1)
+                osld_initializers.NormalCorrelationCholeskyInitializer(0.1)
             )
 
         else:
@@ -666,7 +666,7 @@ class DiagonalMatricesLayer(layers.Layer):
         elif learn:
             # Use random numbers
             self.diagonals_initializer = osld_initializers.NormalDiagonalInitializer(
-                mean=0, std=0.05
+                0.05
             )
 
         else:


### PR DESCRIPTION
Changes:
- Removed the mean argument from the custom initialisers when it is not used/necessary.

I tested the dynemo_hmm-mvn.py and mdynemo_hmm-mvn.py examples after making the changes and they both achieve a dice of ~0.99.