### PR TITLE
Fixed bug in CorrelationMatricesLayer and DiagonalMatricesLayer

### DIFF
--- a/osl_dynamics/inference/layers.py
+++ b/osl_dynamics/inference/layers.py
@@ -598,7 +598,7 @@ class CorrelationMatricesLayer(layers.Layer):
         # Regulariser
         self.regularizer = regularizer
 
-    def add_regularization(self, correlation, inputs):
+    def add_regularization(self, correlations, inputs):
         # Calculate regularisation
         reg = self.regularizer(correlations)
 
@@ -626,7 +626,7 @@ class CorrelationMatricesLayer(layers.Layer):
         correlations = self.bijector(self.flattened_cholesky_factors)
         correlations = add_epsilon(correlations, self.epsilon, diag=True)
         if self.regularizer is not None:
-            self.add_regularization(correlation, inputs)
+            self.add_regularization(correlations, inputs)
         return correlations
 
 
@@ -737,7 +737,7 @@ class DiagonalMatricesLayer(layers.Layer):
         D = self.bijector(self.diagonals)
         D = add_epsilon(D, self.epsilon)
         if self.regularizer is not None:
-            self.add_regularization(diagonals, inputs)
+            self.add_regularization(D, inputs)
         D = tf.linalg.diag(D)
         return D
 


### PR DESCRIPTION
Closes: https://github.com/OHBA-analysis/osl-dynamics/issues/52.

Fixed bug in:
1. [CorrelationMatricesLayer add_regularization typo](https://github.com/OHBA-analysis/osl-dynamics/blob/main/osl_dynamics/inference/layers.py#L601-L603)
2. [CorrelationMatricesLayer call method typo](https://github.com/OHBA-analysis/osl-dynamics/blob/main/osl_dynamics/inference/layers.py#L629)
3. [DiagonalMatricesLayer call method typo](https://github.com/OHBA-analysis/osl-dynamics/blob/main/osl_dynamics/inference/layers.py#L740)