### PR TITLE
Enhance mode analysis: SMA and plotting matrices

### DIFF
--- a/doc/development.rst
+++ b/doc/development.rst
@@ -42,6 +42,9 @@ The core development team is:
 * Evan Roberts <evan.roberts@kellogg.ox.ac.uk>
 * Rukuang Huang <rukuang.huang@jesus.ox.ac.uk>
 * Usama Pervaiz <usama.pervaiz@ndcn.ox.ac.uk>
+* Hongyu Qian <hongyu.qian@queens.ox.ac.uk>
+* Miguel Farinha <miguel.farinha@balliol.ox.ac.uk>
+* SungJun Cho <sungjun.cho@hertford.ox.ac.uk>
 * Mark Woolrich <mark.woolrich@ohba.ox.ac.uk>
 
 With contributions from former group members:

--- a/osl_dynamics/analysis/modes.py
+++ b/osl_dynamics/analysis/modes.py
@@ -599,29 +599,31 @@ def calc_trans_prob_matrix(state_time_course, n_states=None):
 
 
 def simple_moving_average(data, window_length, step_size):
-    """Calculates moving averages by computing the unweighted mean of n observations 
-       over the current time window. Can be used to smooth the fractional occupancy 
-       time courses as in Baker et al. (2014).
+    """Simple moving average.
 
-       Parameters
-       ----------
-       data: np.ndarray
-             Time series data with a shape (n_samples, n_modes)
-       window_length : int
-                       Number of data points in a window
-       step_size : int
-                   Step size for shifting the window
+    Calculates moving averages by computing the unweighted mean of n
+    observations over the current time window. Can be used to smooth
+    the fractional occupancy time courses as in Baker et al. (2014).
 
-       Returns
-       -------
-       mov_avg : np.ndarray
-                 Mean for each window
+    Parameters
+    ----------
+    data: np.ndarray
+        Time series data with a shape (n_samples, n_modes).
+    window_length : int
+        Number of data points in a window.
+    step_size : int
+        Step size for shifting the window.
+
+    Returns
+    -------
+    mov_avg : np.ndarray
+        Mean for each window.
     """
     # Get number of samples and modes
     n_samples = data.shape[0]
     n_modes = data.shape[1]
 
-    # Pad the data    
+    # Pad the data
     data = np.pad(data, window_length // 2)[
         :, window_length // 2 : window_length // 2 + n_modes
     ]
@@ -632,11 +634,11 @@ def simple_moving_average(data, window_length, step_size):
 
     # Preallocate an array to hold moving average values
     mov_avg = np.empty([n_windows, n_modes], dtype=np.float32)
-    
-    # Compute moving average
+
+    # Compute simple moving average
     for n in range(n_windows):
         j = time_idx[n]
-        mov_window = data[j : j + window_length, :] # equivalent to applying a uniform window
-        mov_avg[n, :] = np.mean(mov_window, axis=0)
+        mov_window = data[j : j + window_length]
+        mov_avg[n] = np.mean(mov_window, axis=0)
 
     return mov_avg

--- a/osl_dynamics/analysis/modes.py
+++ b/osl_dynamics/analysis/modes.py
@@ -596,3 +596,47 @@ def calc_trans_prob_matrix(state_time_course, n_states=None):
             tp /= tp.sum(axis=1)[:, None]
         trans_prob.append(np.nan_to_num(tp))
     return np.squeeze(trans_prob)
+
+
+def simple_moving_average(data, window_length, step_size):
+    """Calculates moving averages by computing the unweighted mean of n observations 
+       over the current time window. Can be used to smooth the fractional occupancy 
+       time courses as in Baker et al. (2014).
+
+       Parameters
+       ----------
+       data: np.ndarray
+             Time series data with a shape (n_samples, n_modes)
+       window_length : int
+                       Number of data points in a window
+       step_size : int
+                   Step size for shifting the window
+
+       Returns
+       -------
+       mov_avg : np.ndarray
+                 Mean for each window
+    """
+    # Get number of samples and modes
+    n_samples = data.shape[0]
+    n_modes = data.shape[1]
+
+    # Pad the data    
+    data = np.pad(data, window_length // 2)[
+        :, window_length // 2 : window_length // 2 + n_modes
+    ]
+
+    # Define indices of time points to calculate a moving average
+    time_idx = range(0, n_samples, step_size)
+    n_windows = n_samples // step_size
+
+    # Preallocate an array to hold moving average values
+    mov_avg = np.empty([n_windows, n_modes], dtype=np.float32)
+    
+    # Compute moving average
+    for n in range(n_windows):
+        j = time_idx[n]
+        mov_window = data[j : j + window_length, :] # equivalent to applying a uniform window
+        mov_avg[n, :] = np.mean(mov_window, axis=0)
+
+    return mov_avg

--- a/osl_dynamics/utils/plotting.py
+++ b/osl_dynamics/utils/plotting.py
@@ -1274,8 +1274,8 @@ def plot_matrices(
             axis.remove()
             continue
         if group_color_scale:
-            v_min = matrix.min()
-            v_max = matrix.max()
+            v_min = np.nanmin(matrix)
+            v_max = np.nanmax(matrix)
             if log_norm:
                 im = axis.matshow(
                     grid,


### PR DESCRIPTION
1. Simple moving average [[commit](https://github.com/OHBA-analysis/osl-dynamics/commit/2245ae1f52ee96d94f264c409e48fb2d55e7dbb2)]
   * The simple moving average functionality was added to enable smoothing of fractional occupancy time courses as in Baker et al. (2014). This is similar to `analysis/spectral/window_mean()` function, with main differences lying in the use of subwindows and Hanning window.

2. Plotting matrices [[commit](https://github.com/OHBA-analysis/osl-dynamics/commit/0c34259db4e2f34b27a20848d9a5e624a968fb5c)]
   * While our current `plot_matrices()` function takes in NaN values and allow an argument that sets their colour, `vmin` and `vmax` do not take into account these NaN values. This commit fixes this issue. 