### PR TITLE
fix: compute threshold with a fixed percentile

### DIFF
--- a/osl_dynamics/analysis/gmm.py
+++ b/osl_dynamics/analysis/gmm.py
@@ -115,6 +115,11 @@ def fit_gaussian_mixture(
         abs(means[1] - means[0]) < n_sigma * stddevs[0]
         and one_component_percentile is not None
     ):
+        # Reorder data in an ascending order
+        ascending = np.argsort(X_[:, 0])
+        X_ = X_[ascending]
+        X = X[ascending]
+
         # The Gaussians are not sufficiently distinct to define a threshold
         index = one_component_percentile * len(X) // 100
 


### PR DESCRIPTION
In `gmm.fit_gaussian_mixture()`, the argument `one_component_percentile` is needed to compute the index of the data that corresponds to a user-defined percentile. However, this is not the case, because the data `X_` is not in the ascending order. This commit reorders the input data to take care of this issue.