### PR TITLE
Rescaling regression coefficients of PSDs with maximum alpha values

### DIFF
--- a/osl_dynamics/analysis/spectral.py
+++ b/osl_dynamics/analysis/spectral.py
@@ -1329,6 +1329,9 @@ def rescale_regression_coefs(psd, alpha, window_length, step_size=1, n_sub_windo
     """
 
     # Validation
+    if psd.ndim == 4:
+        psd = psd[np.newaxis, ...]
+
     if psd.ndim != 5:
         raise ValueError(
             "psd must have shape (n_subjects, 2, n_modes, n_channels, n_freqs)."
@@ -1343,6 +1346,10 @@ def rescale_regression_coefs(psd, alpha, window_length, step_size=1, n_sub_windo
             + f"psd and alpha: len(psd)={len(psd)}, "
             + f"len(alpha)={len(alpha)}."
         )
+
+    for i in range(len(alpha)):
+        if alpha[i].shape[1] != psd[i].shape[1]:
+            raise ValueError("psd and alpha must have same number of modes.")
 
     # Number of subjects
     n_subjects = len(alpha)

--- a/osl_dynamics/analysis/spectral.py
+++ b/osl_dynamics/analysis/spectral.py
@@ -1301,3 +1301,66 @@ def spectrogram(
     P /= sampling_frequency * np.sum(window**2)
 
     return t, f, P
+
+
+def rescale_regression_coefs(psd, alpha, window_length, step_size=1, n_sub_windows=1):
+    """Rescales regression coefficients with maximum regressor values.
+
+    Parameters
+    ----------
+    psd : np.ndarray
+        Mode PSDs. Shape must be (n_subjects, 2, n_modes, n_channels, n_freq)
+    alpha : np.ndarray or list
+        Inferred mode mixing factors. Shape must be (n_subjects, n_samples,
+        n_modes) or (n_samples, n_modes).
+    window_length : int
+        Number samples used as the window to calcualte a PSD.
+    step_size : int
+        Step size used for shifting the window.
+    n_sub_windows : int
+        Number of sub-windows used to average the spectra. window_length
+        must be divisible by n_sub_windows.
+
+    Returns
+    -------
+    psd : np.ndarray
+        Mode PSDs, rescaled with maximum regressor values.
+        Shape is identical to the input.
+    """
+
+    # Validation
+    if psd.ndim != 5:
+        raise ValueError(
+            "psd must have shape (n_subjects, 2, n_modes, n_channels, n_freqs)."
+        )
+
+    if isinstance(alpha, np.ndarray):
+        alpha = [alpha]
+
+    if len(psd) != len(alpha):
+        raise ValueError(
+            "A different number of subjects has been passed for "
+            + f"psd and alpha: len(psd)={len(psd)}, "
+            + f"len(alpha)={len(alpha)}."
+        )
+
+    # Number of subjects
+    n_subjects = len(alpha)
+
+    # Window alphas to match the windowing of STFT
+    for i, a in enumerate(alpha):
+        alpha[i] = window_mean(
+            a, window_length, step_size=step_size, n_sub_windows=n_sub_windows
+        )
+
+    # Normalize the alphas
+    alpha = [(a - np.mean(a, axis=0)) / np.std(a, axis=0) for a in alpha]
+
+    # Get maximum regressor values
+    max_alpha = [np.max(a, axis=0) for a in alpha]
+
+    # Rescale the regression coefficients
+    for n in range(n_subjects):
+        psd[n, 0] *= np.expand_dims(max_alpha[n], axis=(1, 2))
+
+    return psd


### PR DESCRIPTION
### Description

As Andrew suggested, plotting `P_0 + P_j` masks the height (contribution) of the alphas on mode PSDs and shows the effect of the mean and when `alpha_j` is one standard deviation above the mean. Instead, plotting `P_0 + P_j * max(alpha_j)` allows us to visualise the moment when the mode is most strongly active. The commits here outputs maximum alpha regressor values and introduces a new function that rescales regression coefficients with these values.

* regression.py [[changes](https://github.com/OHBA-analysis/osl-dynamics/commit/03cc643e270ab8bc971d703b59865e9385c1dd10)]
  We extract the maximum regressor values here, because our regressors are not the raw alphas, but the windowed and potentially z-transformed alpha mixing coefficients.

* spectral.py [[changes](https://github.com/OHBA-analysis/osl-dynamics/commit/8e3e1830907e302b57ee2447af9e37998562cda1)]
   We output the maximum regressor values from `single_regression_spectra()` and `regression_spectra()`. The regressor  coefficients are not rescaled in these functions to ensure flexibility for the users. The function `rescale_regression_coefs()` allows this rescaling, given the outputs from `regression_spectra()`.

Note: Some other changes included due to reformatting with `black`.