### PR TITLE
Save osl-dynamics version with models.

### DIFF
--- a/osl_dynamics/models/__init__.py
+++ b/osl_dynamics/models/__init__.py
@@ -31,12 +31,12 @@ models = {
 }
 
 
-def load(filepath):
-    """Load model from filepath.
+def load(dirname):
+    """Load model from dirname.
 
     Parameters
     ----------
-    filepath : str
+    dirname : str
         Path to directory where the config.yml and weights are stored.
 
     Returns
@@ -44,8 +44,8 @@ def load(filepath):
     model : DyNeMo model
         Model object.
     """
-    with open(f"{filepath}/config.yml", "r") as f:
-        config_dict = yaml.load(f, NumpyLoader)
+    with open(f"{dirname}/config.yml", "r") as file:
+        config_dict = yaml.load(file, NumpyLoader)
 
     if "model_name" not in config_dict:
         raise ValueError(
@@ -61,4 +61,4 @@ def load(filepath):
             + f"Options are {', '.join(models.keys())}"
         )
 
-    return model_type.load(filepath)
+    return model_type.load(dirname)


### PR DESCRIPTION
Closes: https://github.com/OHBA-analysis/osl-dynamics/issues/66.

Changes:
- A `Model.version` attribute was added to the model base class.
- A header comment was added to the `config.yml` file when we save a model which contains the version of osl-dynamics used when saving the model.
- The version is automatically read from the config file when loading models.

Note, we load models with a config file that doesn't have a header, we set the version to "<1.1.6".