### PR TITLE
Add: Allow returning matplotlib objects when plotting power maps

### DIFF
--- a/osl_dynamics/analysis/power.py
+++ b/osl_dynamics/analysis/power.py
@@ -191,7 +191,6 @@ def save(
     subtract_mean=False,
     mean_weights=None,
     plot_kwargs=None,
-    display=True,
 ):
     """Saves power maps.
 
@@ -209,8 +208,8 @@ def save(
     filename : str
         Output filename. If extension is .nii.gz the power map is saved as a
         NIFTI file. Or if the extension is png/svg/pdf, it is saved as images.
-        Optional, if None is passed then the image is shown on screen or the
-        Matplotlib objects are returned, depending on the `display` argument.
+        Optional, if None is passed then the image is shown on screen and the
+        Matplotlib objects are returned.
     component : int
         Spectral component to save.
     subtract_mean : bool
@@ -220,16 +219,13 @@ def save(
         Default is equal weighting.
     plot_kwargs : dict
         Keyword arguments to pass to nilearn.plotting.plot_img_on_surf.
-    display: bool
-        Whether to display the image on screen. Filename must be set as None for
-        the argument to be active. If False, the Matplotlib objects are returned.
 
     Returns
     -------
-    fig : matplotlib.pyplot.figure
-        Matplotlib figure object.
-    ax : matplotlib.pyplot.axis.
-        Matplotlib axis object(s).
+    figures : list of matplotlib.pyplot.figure
+        List of Matplotlib figure object.
+    axes : list of matplotlib.pyplot.axis.
+        List of Matplotlib axis object(s).
     """
     # Create a copy of the power map so we don't modify it
     power_map = np.copy(power_map)
@@ -292,25 +288,19 @@ def save(
 
     # Just display the power map
     if filename is None:
+        figures, axes = [], []
         for i in trange(n_modes, desc="Saving images"):
             nii = nib.Nifti1Image(power_map[:, :, :, i], mask.affine, mask.header)
-            if display:
-                plotting.plot_img_on_surf(
-                    nii,
-                    views=["lateral", "medial"],
-                    hemispheres=["left", "right"],
-                    colorbar=True,
-                    **plot_kwargs,
-                )
-            else:
-                fig, ax = plotting.plot_img_on_surf(
-                    nii,
-                    views=["lateral", "medial"],
-                    hemispheres=["left", "right"],
-                    colorbar=True,
-                    **plot_kwargs,
-                )
-                return fig, ax
+            fig, ax = plotting.plot_img_on_surf(
+                nii,
+                views=["lateral", "medial"],
+                hemispheres=["left", "right"],
+                colorbar=True,
+                **plot_kwargs,
+            )
+            figures.append(fig)
+            axes.append(ax)
+        return figures, axes
 
     else:
         # Save as nii file

--- a/osl_dynamics/analysis/power.py
+++ b/osl_dynamics/analysis/power.py
@@ -191,6 +191,7 @@ def save(
     subtract_mean=False,
     mean_weights=None,
     plot_kwargs=None,
+    display=True,
 ):
     """Saves power maps.
 
@@ -208,7 +209,8 @@ def save(
     filename : str
         Output filename. If extension is .nii.gz the power map is saved as a
         NIFTI file. Or if the extension is png/svg/pdf, it is saved as images.
-        Optional, if None is passed then the image is shown on screen.
+        Optional, if None is passed then the image is shown on screen or the
+        Matplotlib objects are returned, depending on the `display` argument.
     component : int
         Spectral component to save.
     subtract_mean : bool
@@ -218,6 +220,16 @@ def save(
         Default is equal weighting.
     plot_kwargs : dict
         Keyword arguments to pass to nilearn.plotting.plot_img_on_surf.
+    display: bool
+        Whether to display the image on screen. Filename must be set as None for
+        the argument to be active. If False, the Matplotlib objects are returned.
+
+    Returns
+    -------
+    fig : matplotlib.pyplot.figure
+        Matplotlib figure object.
+    ax : matplotlib.pyplot.axis.
+        Matplotlib axis object(s).
     """
     # Create a copy of the power map so we don't modify it
     power_map = np.copy(power_map)
@@ -282,13 +294,23 @@ def save(
     if filename is None:
         for i in trange(n_modes, desc="Saving images"):
             nii = nib.Nifti1Image(power_map[:, :, :, i], mask.affine, mask.header)
-            plotting.plot_img_on_surf(
-                nii,
-                views=["lateral", "medial"],
-                hemispheres=["left", "right"],
-                colorbar=True,
-                **plot_kwargs,
-            )
+            if display:
+                plotting.plot_img_on_surf(
+                    nii,
+                    views=["lateral", "medial"],
+                    hemispheres=["left", "right"],
+                    colorbar=True,
+                    **plot_kwargs,
+                )
+            else:
+                fig, ax = plotting.plot_img_on_surf(
+                    nii,
+                    views=["lateral", "medial"],
+                    hemispheres=["left", "right"],
+                    colorbar=True,
+                    **plot_kwargs,
+                )
+                return fig, ax
 
     else:
         # Save as nii file

--- a/osl_dynamics/utils/plotting.py
+++ b/osl_dynamics/utils/plotting.py
@@ -1573,6 +1573,7 @@ def plot_brain_surface(
     filename=None,
     subtract_mean=False,
     mean_weights=None,
+    display=True,
     **plot_kwargs,
 ):
     """Plot a 2D heat map on the surface of the brain.
@@ -1590,16 +1591,41 @@ def plot_brain_surface(
     filename : str
         Output filename. If extension is .nii.gz the power map is saved as a
         NIFTI file. Or if the extension is png/svg/pdf, it is saved as images.
-        Optional, if None is passed then the image is shown on screen.
+        Optional, if None is passed then the image is shown on screen or the
+        Matplotlib objects are returned, depending on the `display` argument.
     subtract_mean : bool
         Should we subtract the mean power across modes?
     mean_weights: np.ndarray
         Numpy array with weightings for each mode to use to calculate the mean.
         Default is equal weighting.
+    display: bool
+        Whether to display the image on screen. Filename must be set as None for
+        the argument to be active. If False, the Matplotlib objects are returned.
     plot_kwargs : dict
         Keyword arguments to pass to nilearn.plotting.plot_img_on_surf.
+
+    Returns
+    -------
+    fig : matplotlib.pyplot.figure
+        Matplotlib figure object.
+    ax : matplotlib.pyplot.axis.
+        Matplotlib axis object(s).
     """
     from osl_dynamics.analysis import power
+
+    if filename is None and not display:
+        fig, ax = power.save(
+            power_map=values,
+            filename=filename,
+            mask_file=mask_file,
+            parcellation_file=parcellation_file,
+            subtract_mean=subtract_mean,
+            mean_weights=mean_weights,
+            display=display,
+            **plot_kwargs,
+        )
+
+        return fig, ax
 
     power.save(
         power_map=values,

--- a/osl_dynamics/utils/plotting.py
+++ b/osl_dynamics/utils/plotting.py
@@ -1573,7 +1573,6 @@ def plot_brain_surface(
     filename=None,
     subtract_mean=False,
     mean_weights=None,
-    display=True,
     **plot_kwargs,
 ):
     """Plot a 2D heat map on the surface of the brain.
@@ -1591,41 +1590,36 @@ def plot_brain_surface(
     filename : str
         Output filename. If extension is .nii.gz the power map is saved as a
         NIFTI file. Or if the extension is png/svg/pdf, it is saved as images.
-        Optional, if None is passed then the image is shown on screen or the
-        Matplotlib objects are returned, depending on the `display` argument.
+        Optional, if None is passed then the image is shown on screen and the
+        Matplotlib objects are returned.
     subtract_mean : bool
         Should we subtract the mean power across modes?
     mean_weights: np.ndarray
         Numpy array with weightings for each mode to use to calculate the mean.
         Default is equal weighting.
-    display: bool
-        Whether to display the image on screen. Filename must be set as None for
-        the argument to be active. If False, the Matplotlib objects are returned.
     plot_kwargs : dict
         Keyword arguments to pass to nilearn.plotting.plot_img_on_surf.
 
     Returns
     -------
-    fig : matplotlib.pyplot.figure
-        Matplotlib figure object.
-    ax : matplotlib.pyplot.axis.
-        Matplotlib axis object(s).
+    figures : list of matplotlib.pyplot.figure
+        List of Matplotlib figure object.
+    axes : list of matplotlib.pyplot.axis.
+        List of Matplotlib axis object(s).
     """
     from osl_dynamics.analysis import power
 
-    if filename is None and not display:
-        fig, ax = power.save(
+    if filename is None:
+        figures, axes = power.save(
             power_map=values,
             filename=filename,
             mask_file=mask_file,
             parcellation_file=parcellation_file,
             subtract_mean=subtract_mean,
             mean_weights=mean_weights,
-            display=display,
             **plot_kwargs,
         )
-
-        return fig, ax
+        return figures, axes
 
     power.save(
         power_map=values,


### PR DESCRIPTION
These commits allow `power.save()` and `plotting.plot_brain_surface()` function to return matplotlib figure and axis objects when `filename=None` and `display=False`. Since the default option for `display` is `True`, I believe this edit will not require previous codes and tutorials to be changed.