### PR TITLE
feat: add axis argument to plot_alpha

### DIFF
--- a/osl_dynamics/utils/plotting.py
+++ b/osl_dynamics/utils/plotting.py
@@ -1605,6 +1605,7 @@ def plot_alpha(
     plot_kwargs=None,
     fig_kwargs=None,
     filename=None,
+    axes=None,
 ):
     """Plot alpha.
 
@@ -1628,6 +1629,8 @@ def plot_alpha(
         Arguments to pass to matplotlib.pyplot.subplots.
     filename : str
         Output filename.
+    axes: list of matplotlib.pyplot.Axes
+        A list of matplotlib axes to plot on. If None, a new figure is created.
 
     Returns
     -------
@@ -1637,6 +1640,11 @@ def plot_alpha(
         Matplotlib axis object(s). Only returned if filename=None.
     """
     n_alphas = len(alpha)
+    if isinstance(axes, plt.Axes):
+        axes = [axes]
+    if axes is not None and len(axes) != n_alphas:
+        raise ValueError("Number of axes must match number of alphas.")
+
     n_modes = max(a.shape[1] for a in alpha)
     n_samples = min(n_samples or np.inf, alpha[0].shape[0])
     if cmap in [
@@ -1680,12 +1688,11 @@ def plot_alpha(
     elif len(y_labels) != n_alphas:
         raise ValueError("Incorrect number of y_labels passed.")
 
-    # Create figure
-    fig, axes = create_figure(n_alphas, **fig_kwargs)
-
-    # If n_alphas is one then axes won't be iterable
-    if not isinstance(axes, np.ndarray):
-        axes = [axes]
+    # Create figure if axes not passed
+    if axes is None:
+        fig, axes = create_figure(n_alphas, **fig_kwargs)
+    else:
+        fig = axes[0].get_figure()
 
     # Plot data
     for a, ax, y_label in zip(alpha, axes, y_labels):


### PR DESCRIPTION

It is sometimes desirable to add alpha stackplots to existing figures. If multiple alphas are passed, multiple axes must also be used. A check is added to make sure there are an equal number of alphas and axes.

Changes:
```
axes=None -> no change (fig and axes created)
axes=single_axis -> wrap in a list
axes=multiple_axes -> check same number of axes as alphas
```
