### PR TITLE
feat: github action to check black linting

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,12 @@
+name: Lint
+
+on: [pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: psf/black@stable
+        with:
+        src: "./osl_dynamics"


### PR DESCRIPTION
We should be checking our source code for Black compliance every time we approve a pull request. This PR adds a github action to automate this. It should be non-blocking, but will mark the pull request as non-compliant so that it can be fixed before acceptance.