### PR TITLE
Add detail to logging format

### DIFF
--- a/osl_dynamics/__init__.py
+++ b/osl_dynamics/__init__.py
@@ -14,7 +14,7 @@ finally:
 
 # Configure logging
 logging.basicConfig(
-    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    format="%(asctime)s %(levelname)s %(name)s [%(filename)s:%(lineno)d:%(funcName)s]: %(message)s",
     datefmt="%Y-%m-%d %H:%M:%S",
     level=logging.INFO,
 )

--- a/osl_dynamics/config_api/pipeline.py
+++ b/osl_dynamics/config_api/pipeline.py
@@ -128,7 +128,8 @@ def run_pipeline(config, output_dir, data=None, extra_funcs=None):
                 _logger.info(f"{name}: {kwargs}")
                 func(data=data, output_dir=output_dir, **kwargs)
             except Exception as e:
-                _logger.error(e)
+                _logger.exception(e)
+
 
     # Delete the temporary directory created by the Data class
     if data is not None:


### PR DESCRIPTION
Adding paths, line numbers and functions to logs makes them far more useful:

Old:
```
2023-04-12 11:45:31 ERROR osl-dynamics: x and y must have same first dimension, but have shapes (45,) and (1,)
```
_Cryptic, unhelpful, 💩_

New:
```
2023-04-12 11:45:31 ERROR osl-dynamics [pipeline.py:131:run_pipeline]: x and y must have same first dimension, but have shapes (45,) and (1,)
```
_Explicit, detailed, 🔥_

Gets a bit long so we might consider putting the text of the error on the next line?
