### PR TITLE
Fix: update to reflect changed History objects

### DIFF
--- a/examples/meg/notts_movie_opm/dynemo_full-pipeline.py
+++ b/examples/meg/notts_movie_opm/dynemo_full-pipeline.py
@@ -100,7 +100,7 @@ if not use_pre_trained_model:
     init_history = model.multistart_initialization(training_data, n_epochs=20, n_init=10)
 
     with open(f"{model_dir}/init_history.pkl", "wb") as file:
-        pickle.dump(init_history.history, file)
+        pickle.dump(init_history, file)
 
     # Main training on the full dataset
     print("Training final model")
@@ -111,7 +111,7 @@ if not use_pre_trained_model:
     )
 
     with open(f"{model_dir}/history.pkl", "wb") as file:
-        pickle.dump(history.history, file)
+        pickle.dump(history, file)
 
 else:
     # Load a pre-trained model

--- a/examples/meg/uk_meg_notts/dynemo_full-rest-pipeline.py
+++ b/examples/meg/uk_meg_notts/dynemo_full-rest-pipeline.py
@@ -93,7 +93,7 @@ model.single_subject_initialization(
 init_history = model.multistart_initialization(training_data, n_epochs=20, n_init=10)
 
 with open(f"{model_dir}/init_history.pkl", "wb") as file:
-    pickle.dump(init_history.history, file)
+    pickle.dump(init_history, file)
 
 print("Training final model")
 history = model.fit(
@@ -103,7 +103,7 @@ history = model.fit(
 )
 
 with open(f"{model_dir}/history.pkl", "wb") as file:
-    pickle.dump(history.history, file)
+    pickle.dump(history, file)
 
 '''
 # Load a pre-trained model

--- a/osl_dynamics/config_api/pipeline.py
+++ b/osl_dynamics/config_api/pipeline.py
@@ -109,7 +109,6 @@ def run_pipeline(config, output_dir, data=None, extra_funcs=None):
     # Load data via the config
     load_data_kwargs = config.pop("load_data", None)
     if load_data_kwargs is not None:
-
         # Make sure the Data class uses a unique temporary directory
         data_kwargs = load_data_kwargs.pop("data_kwargs", {})
         default_data_kwargs = {"store_dir": f"tmp_{config_id}"}

--- a/osl_dynamics/models/inf_mod_base.py
+++ b/osl_dynamics/models/inf_mod_base.py
@@ -186,7 +186,7 @@ class VariationalInferenceModelBase(ModelBase):
             self.reset()
             training_data_subset = training_data.shuffle(100000).take(n_batches)
             history = self.fit(training_data_subset, epochs=n_epochs, **kwargs)
-            loss = history.history["loss"][-1]
+            loss = history["loss"][-1]
             if loss < best_loss:
                 best_initialization = n
                 best_loss = loss
@@ -265,7 +265,7 @@ class VariationalInferenceModelBase(ModelBase):
             # Reset the model weights and train
             self.reset()
             history = self.fit(subject_dataset, epochs=n_epochs, **kwargs)
-            loss = history.history["loss"][-1]
+            loss = history["loss"][-1]
             losses.append(loss)
             _logger.info(f"Subject {subject} loss: {loss}")
 

--- a/osl_dynamics/models/mod_base.py
+++ b/osl_dynamics/models/mod_base.py
@@ -231,7 +231,8 @@ class ModelBase:
         if use_tqdm:
             args, kwargs = replace_argument(self.model.fit, "verbose", 0, args, kwargs)
 
-        return self.model.fit(*args, **kwargs)
+        history = self.model.fit(*args, **kwargs)
+        return history.history
 
     def load_weights(self, filepath):
         """Load weights of the model from a file.

--- a/osl_dynamics/models/state_dynemo.py
+++ b/osl_dynamics/models/state_dynemo.py
@@ -243,7 +243,7 @@ class Model(DyNeMo):
             training_dataset.shuffle(100000)
             training_data_subset = training_dataset.take(n_batches)
             history = self.fit(training_data_subset, epochs=n_epochs, **kwargs)
-            loss = history.history["loss"][-1]
+            loss = history["loss"][-1]
             if loss < best_loss:
                 best_initialization = n
                 best_loss = loss


### PR DESCRIPTION
TF history objects now contain a reference to the model. Pickling history objects attempts to save the model in h5 format. This fails and prevents objects from being loaded. Instead, we return `history.history` from the base model fit function.

This is a problem for at least TF2.11.