### PR TITLE
Fix: plot_alphas bug when axes=None

### DIFF
--- a/osl_dynamics/utils/plotting.py
+++ b/osl_dynamics/utils/plotting.py
@@ -1694,6 +1694,9 @@ def plot_alpha(
     else:
         fig = axes[0].get_figure()
 
+    if isinstance(axes, plt.Axes):
+        axes = [axes]
+
     # Plot data
     for a, ax, y_label in zip(alpha, axes, y_labels):
         time_vector = (


### PR DESCRIPTION
Fixed bug introduced in #113 for `plot_alpha`.

Bug occured when `axes=None` __and__ `len(alphas) == 1`.