### PR TITLE
Add CLI interface for config_api

### DIFF
--- a/osl_dynamics/config_api/cli.py
+++ b/osl_dynamics/config_api/cli.py
@@ -5,7 +5,7 @@ import argparse
 from osl_dynamics.config_api.pipeline import run_pipeline_from_file
 
 
-def pipeline() -> None:
+def pipeline():
     """Run a pipeline from a config file."""
     parser = argparse.ArgumentParser()
     parser.add_argument(

--- a/osl_dynamics/config_api/cli.py
+++ b/osl_dynamics/config_api/cli.py
@@ -1,0 +1,32 @@
+"""Functions for running full pipelines via the config API."""
+
+import argparse
+
+from osl_dynamics.config_api.pipeline import run_pipeline_from_file
+
+
+def pipeline() -> None:
+    """Run a pipeline from a config file."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "config_file",
+        type=str,
+        help="Path to the config file.",
+    )
+    parser.add_argument(
+        "output_directory",
+        type=str,
+        help="Path to the output directory.",
+    )
+    parser.add_argument(
+        "--restrict",
+        type=str,
+        help="GPU to use. Optional.",
+    )
+    args = parser.parse_args()
+
+    run_pipeline_from_file(
+        args.config_file,
+        args.output_directory,
+        restrict=args.restrict,
+    )

--- a/osl_dynamics/config_api/pipeline.py
+++ b/osl_dynamics/config_api/pipeline.py
@@ -137,10 +137,10 @@ def run_pipeline(config, output_dir, data=None, extra_funcs=None):
 
 
 def run_pipeline_from_file(
-    config_file: str,
-    output_directory: str,
-    restrict: str = None,
-) -> None:
+    config_file,
+    output_directory,
+    restrict: str,
+):
     """Run a pipeline from a config file.
 
     Parameters

--- a/osl_dynamics/config_api/pipeline.py
+++ b/osl_dynamics/config_api/pipeline.py
@@ -5,12 +5,14 @@ See the `toolbox examples
 for scripts that use the config API.
 """
 
-import os
 import logging
-import yaml
-import pprint
+import os
 import pickle
+import pprint
+from pathlib import Path
+
 import numpy as np
+import yaml
 
 from osl_dynamics.config_api import wrappers
 from osl_dynamics.utils.misc import override_dict_defaults
@@ -132,3 +134,19 @@ def run_pipeline(config, output_dir, data=None, extra_funcs=None):
     # Delete the temporary directory created by the Data class
     if data is not None:
         data.delete_dir()
+
+
+def run_pipeline_from_file(config_file: str, output_directory: str):
+    """Run a pipeline from a config file.
+
+    Parameters
+    ----------
+    config_file : str
+        Path to the config file.
+    output_directory : str
+        Path to the output directory.
+    """
+    config_path = Path(config_file)
+    config = config_path.read_text()
+
+    run_pipeline(config, output_directory)

--- a/osl_dynamics/config_api/pipeline.py
+++ b/osl_dynamics/config_api/pipeline.py
@@ -136,7 +136,11 @@ def run_pipeline(config, output_dir, data=None, extra_funcs=None):
         data.delete_dir()
 
 
-def run_pipeline_from_file(config_file: str, output_directory: str):
+def run_pipeline_from_file(
+    config_file: str,
+    output_directory: str,
+    restrict: str = None,
+) -> None:
     """Run a pipeline from a config file.
 
     Parameters
@@ -145,7 +149,14 @@ def run_pipeline_from_file(config_file: str, output_directory: str):
         Path to the config file.
     output_directory : str
         Path to the output directory.
+    restrict : str
+        GPU to use. Optional.
     """
+    if restrict is not None:
+        from osl_dynamics.inference.tf_ops import gpu_growth, select_gpu
+
+        select_gpu(int(restrict))
+        gpu_growth()
     config_path = Path(config_file)
     config = config_path.read_text()
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,3 +56,7 @@ where = osl_dynamics
 [build_sphinx]
 source_dir = doc
 build_dir = build/sphinx
+
+[options.entry_points]
+console_scripts =
+    osld-pipeline = osl_dynamics.config_api.cli:pipeline


### PR DESCRIPTION
Allow a restricted set of the config_api to be run via the command line. Help documentation provided by argparse.

```bash
usage: osld-pipeline [-h] [--restrict RESTRICT] config_file output_directory

positional arguments:
  config_file          Path to the config file.
  output_directory     Path to the output directory.

options:
  -h, --help           show this help message and exit
  --restrict RESTRICT  GPU to use. Optional.
```

example usage:
```bash
osld-pipeline config.yml results --restrict 0
```
This will run a pipeline defined in config.yml.
The results are stored in the directory 'results'.
The pipeline will run on GPU:0 with memory growth enabled.
