### PR TITLE
Prevent `NaN` values in mean lifetimes and intervals

### DIFF
--- a/osl_dynamics/analysis/modes.py
+++ b/osl_dynamics/analysis/modes.py
@@ -192,7 +192,7 @@ def _slice_length(slice_):
     return slice_.stop - slice_.start
 
 
-def _apply_to_lists(list_of_lists, func):
+def _apply_to_lists(list_of_lists, func, check_empty=True):
     """Apply a function to each list in a list of lists.
 
     Parameters
@@ -201,12 +201,26 @@ def _apply_to_lists(list_of_lists, func):
         List of lists.
     func : callable
         Function to apply to each list.
+    check_empty : bool
+        Return 0 for empty lists if set as True. If False, the function
+        will be applied to an empty list.
 
     Returns
     -------
     result : np.ndarray
         Numpy array with the function applied to each list.
     """
+    if check_empty:
+        return np.array(
+            [
+                [
+                    func(inner_list) if np.any(inner_list) else 0
+                    for inner_list in subject_list
+                ]
+                for subject_list in list_of_lists
+            ],
+        )
+
     return np.array(
         [
             [func(inner_list) for inner_list in subject_list]


### PR DESCRIPTION
In some cases in which a state or mode has a zero activation, mean lifetimes and intervals can return `NaN` values.

This is because if there is no activation within a sliced time course, `modes.lifetimes()` will output an empty array, which later outputs 'NaN' when `np.mean` or `np.std` is applied.

Using `np.nanmean` (as initially suggested) does not work.
```
np.nanmean(np.array([]))
>> nan
```

Instead, the function `_apply_to_lists` was edited such that if a list is empty, 0 is returned. Therefore, any sliced time course with zero activation will have summary metric of 0.

With this change, lifetimes and intervals do not have `NaN` values anymore. If this change seems to be insufficient as an alternative, I'll revert the commit. 