### PR TITLE
feat: add ability to plot asymmetric maps

### DIFF
--- a/osl_dynamics/analysis/power.py
+++ b/osl_dynamics/analysis/power.py
@@ -2,10 +2,11 @@
 
 """
 
-import os
 import logging
+import os
 from pathlib import Path
 
+import matplotlib.pyplot as plt
 import nibabel as nib
 import numpy as np
 from nilearn import plotting
@@ -254,6 +255,7 @@ def save(
     component=0,
     subtract_mean=False,
     mean_weights=None,
+    asymmetric_data=False,
     plot_kwargs=None,
 ):
     """Saves power maps.
@@ -281,6 +283,10 @@ def save(
     mean_weights: np.ndarray
         Numpy array with weightings for each mode to use to calculate the mean.
         Default is equal weighting.
+    asymmetric_data : bool
+        If True, the power map is scaled to the range [-1, 1] before plotting.
+        The colorbar is rescaled to show the correct values. Useful for plotting
+        maps of statistics such as lifetimes.
     plot_kwargs : dict
         Keyword arguments to pass to `nilearn.plotting.plot_img_on_surf
         <https://nilearn.github.io/stable/modules/generated/nilearn.plotting.plot_img_on_surf.html>`_.
@@ -354,6 +360,16 @@ def save(
     # Select the component to plot
     power_map = power_map[component]
 
+    original_max = power_map.max()
+    original_min = power_map.min()
+
+    if asymmetric_data:
+        # Scale power map to be between -1 and 1
+        power_map -= power_map.min()
+        power_map /= power_map.max()
+        power_map *= 2
+        power_map -= 1
+
     # Calculate power map grid
     power_map = power_map_grid(mask_file, parcellation_file, power_map)
 
@@ -370,6 +386,7 @@ def save(
         "colorbar": True,
     }
     plot_kwargs = utils.misc.override_dict_defaults(default_plot_kwargs, plot_kwargs)
+    cmap = plot_kwargs.get("cmap", "cold_hot")
 
     # Just display the power map
     if filename is None:
@@ -379,6 +396,15 @@ def save(
             fig, ax = plotting.plot_img_on_surf(nii, output_file=None, **plot_kwargs)
             figures.append(fig)
             axes.append(ax)
+            if asymmetric_data:
+                plt.colorbar(
+                    plt.cm.ScalarMappable(
+                        plt.matplotlib.colors.Normalize(original_min, original_max),
+                        cmap=cmap,
+                    ),
+                    cax=ax[-1],
+                    orientation="horizontal",
+                )
         return figures, axes
 
     else:


### PR DESCRIPTION
`nilearn` automatically chooses symmetrical color ranges. This is problematic when dealing with surface maps for quantities which do not behave like power data. An example is lifetimes which could exist for example between 250 and 350ms.

Following changes:

```python
power.save(
    power_map=lifetimes,
    mask_file="mask_file_name",
    parcellation_file="parcellation_file_name",
    asymmetric_data=False,  # The default value
)  
```
<img src="https://user-images.githubusercontent.com/17300500/234920480-d6876b95-c0b6-4d48-af5d-0cdbf4e1339b.png" width=400>

```python
power.save(
    power_map=lifetimes,
    mask_file="mask_file_name",
    parcellation_file="parcellation_file_name",
    asymmetric_data=True,
)  
```
<img src="https://user-images.githubusercontent.com/17300500/234920340-368a0291-77d2-4559-a1ae-8c5fb7625022.png" width=400>
