### PR TITLE
Fix: reinitialisation bug

### DIFF
--- a/osl_dynamics/inference/initializers.py
+++ b/osl_dynamics/inference/initializers.py
@@ -2,11 +2,14 @@
 
 """
 
+from copy import deepcopy
+
 import numpy as np
-import tensorflow_probability as tfp
 import tensorflow as tf
+import tensorflow_probability as tfp
 from tensorflow.keras import Model, layers, initializers
 from tensorflow.keras.initializers import Initializer
+
 from osl_dynamics import inference
 
 tfb = tfp.bijectors
@@ -183,8 +186,7 @@ def reinitialize_layer_weights(layer):
             #
             # We need to create a new initializer to get new
             # random values
-            new_initializer = initializer_type()
-            init_container.__dict__[key] = new_initializer
+            new_initializer = deepcopy(initializer)
 
         # Get the variable (i.e. weights) we want to re-initialize
         if key == "recurrent_initializer":

--- a/osl_dynamics/models/hmm.py
+++ b/osl_dynamics/models/hmm.py
@@ -305,8 +305,7 @@ class Model(ModelBase):
                 best_initialization = n
                 best_loss = loss
                 best_history = history
-                best_weights = self.get_weights()
-                best_trans_prob = self.trans_prob
+                best_weights, best_trans_prob = self.get_weights()
 
         if best_loss == np.Inf:
             _logger.error("Initialization failed")
@@ -375,8 +374,7 @@ class Model(ModelBase):
                 best_initialization = n
                 best_loss = loss
                 best_history = history
-                best_weights = self.get_weights()
-                best_trans_prob = self.trans_prob
+                best_weights, best_trans_prob = self.get_weights()
 
         if best_loss == np.Inf:
             _logger.error("Initialization failed")
@@ -1204,6 +1202,18 @@ class Model(ModelBase):
         """
         self.trans_prob = np.load(op.join(str(Path(filepath).parent), "trans_prob.npy"))
         return self.model.load_weights(filepath)
+
+    def get_weights(self):
+        """Get model parameter weights.
+
+        Returns
+        -------
+        weights : tensorflow weights
+            TensorFlow weights for the observation model.
+        trans_prob : np.ndarray
+            Transition probability matrix.
+        """
+        return self.model.get_weights(), self.trans_prob
 
     def set_weights(self, weights, trans_prob):
         """Set model parameter weights.


### PR DESCRIPTION
- TensorFlow 2.10 onwards changed the default behaviour of initializers.
- This meant we needed to update our re-initialization function.
- Our function did not account for non-default arguments when the initializer is created.
- This PR fixes the re-initialization function.