### PR TITLE
Refact: Scaling factor

### DIFF
--- a/osl_dynamics/inference/layers.py
+++ b/osl_dynamics/inference/layers.py
@@ -375,16 +375,10 @@ class LearnableTensorLayer(layers.Layer):
         # This should be a function of the tensor that returns a float
         self.regularizer = regularizer
 
-    def add_regularization(self, tensor, inputs):
+    def add_regularization(self, tensor, scaling_factor):
         # Calculate the regularisation from the tensor
         reg = self.regularizer(tensor)
-
-        # Calculate the scaling factor for the regularization
-        # Note, inputs.shape[0] must be the batch size
-        batch_size = tf.cast(tf.shape(inputs)[0], tf.float32)
-        n_batches = self.regularizer.n_batches
-        scaling_factor = batch_size * n_batches
-        reg /= scaling_factor
+        reg *= scaling_factor
 
         # Add regularization to the loss and display while training
         self.add_loss(reg)
@@ -401,9 +395,9 @@ class LearnableTensorLayer(layers.Layer):
         )
         self.built = True
 
-    def call(self, inputs, training=None, **kwargs):
+    def call(self, inputs, scaling_factor=1, training=None, **kwargs):
         if self.regularizer is not None and training:
-            self.add_regularization(self.tensor, inputs)
+            self.add_regularization(self.tensor, scaling_factor)
         return self.tensor
 
 
@@ -1296,23 +1290,19 @@ class MixSubjectSpecificParametersLayer(layers.Layer):
 
 class StaticKLDivergenceLayer(layers.Layer):
     """Layer to calculate KL divergence between Gamma posterior
-    and exponential prior for static parameters.
+    and exponential prior for deviation magnitude.
 
     Parameters
     ----------
     epsilon : float
         Error added to the standard deviations for numerical stability.
-    n_batches : int
-        Number of batches in the data. This is for calculating
-        the scaling factor.
     """
 
-    def __init__(self, epsilon, n_batches=1, **kwargs):
+    def __init__(self, epsilon, **kwargs):
         super().__init__(**kwargs)
         self.epsilon = epsilon
-        self.n_batches = n_batches
 
-    def call(self, inputs, **kwargs):
+    def call(self, inputs, scaling_factor=1, **kwargs):
         data, inference_alpha, inference_beta, model_beta = inputs
 
         # Add a small error for numerical stability
@@ -1329,12 +1319,7 @@ class StaticKLDivergenceLayer(layers.Layer):
             posterior, prior, allow_nan_stats=False
         )
 
-        # Calculate the scaling for KL loss
-        batch_size = tf.cast(tf.shape(data)[0], tf.float32)
-        scaling_factor = batch_size * self.n_batches
-        kl_loss /= scaling_factor
-
-        kl_loss = tf.reduce_sum(kl_loss)
+        kl_loss = tf.reduce_sum(kl_loss) * scaling_factor
 
         return kl_loss
 
@@ -1369,13 +1354,11 @@ class MultiLayerPerceptronLayer(layers.Layer):
         drop_rate,
         regularizer=None,
         regularizer_factor=0.0,
-        n_batches=1,
         **kwargs,
     ):
         super().__init__(**kwargs)
         self.regularizer = regularizers.get(regularizer)
         self.regularizer_factor = regularizer_factor
-        self.n_batches = n_batches
         self.layers = []
         for _ in range(n_layers):
             self.layers.append(layers.Dense(n_units))
@@ -1383,12 +1366,8 @@ class MultiLayerPerceptronLayer(layers.Layer):
             self.layers.append(layers.Activation(act_type))
             self.layers.append(layers.Dropout(drop_rate))
 
-    def call(self, inputs, training=None, **kwargs):
+    def call(self, inputs, scaling_factor=1, training=None, **kwargs):
         reg = 0.0
-        data, inputs = inputs
-
-        batch_size = tf.cast(tf.shape(data)[0], tf.float32)
-        scaling_factor = batch_size * self.n_batches
         for layer in self.layers:
             inputs = layer(inputs, **kwargs)
             if self.regularizer is not None and isinstance(layer, layers.Dense):
@@ -1397,7 +1376,29 @@ class MultiLayerPerceptronLayer(layers.Layer):
 
         if self.regularizer is not None and training:
             reg *= self.regularizer_factor
-            reg /= scaling_factor
+            reg *= scaling_factor
             self.add_loss(reg)
             self.add_metric(reg, name=self.name)
         return inputs
+
+
+class ScalingFactorLayer(layers.Layer):
+    """Layer to calculate the scaling factor for KL loss and
+    regularisation of static quantities.
+
+    When calculating loss, we sum over the sequence length and
+    average over the sequences. The scaling factor is given by
+
+    .. math::
+        \text{scaling_factor} = \frac{1}{\text{batch_size} \times \text{n_batches}}
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.n_batches = 1
+
+    def call(self, inputs, **kwargs):
+        # Note that inputs.shape[0] must be the batch size
+        batch_size = tf.cast(tf.shape(inputs)[0], tf.float32)
+        scaling_factor = 1 / (batch_size * self.n_batches)
+        return scaling_factor

--- a/osl_dynamics/inference/regularizers.py
+++ b/osl_dynamics/inference/regularizers.py
@@ -23,16 +23,13 @@ class InverseWishart(regularizers.Regularizer):
         Shape must be (n_channels, n_channels).
     epsilon : float
         Error added to the diagonal of the covariances.
-    n_batches : int
-        Number of batches in the data.
     """
 
-    def __init__(self, nu, psi, epsilon, n_batches, **kwargs):
+    def __init__(self, nu, psi, epsilon, **kwargs):
         super().__init__(**kwargs)
         self.nu = nu
         self.psi = psi
         self.epsilon = epsilon
-        self.n_batches = n_batches
         self.n_channels = psi.shape[-1]
         self.bijector = tfb.Chain([tfb.CholeskyOuterProduct(), tfb.FillScaleTriL()])
 
@@ -77,15 +74,12 @@ class MultivariateNormal(regularizers.Regularizer):
     sigma : np.ndarray
         2D numpy array of covariance matrix of the prior.
         Shape must be (n_channels, n_channels).
-    n_batches : int
-        Number of batches in the data.
     """
 
-    def __init__(self, mu, sigma, n_batches, **kwargs):
+    def __init__(self, mu, sigma, **kwargs):
         super().__init__(**kwargs)
         self.mu = mu
         self.sigma = sigma
-        self.n_batches = n_batches
 
         # Validation
         if self.mu.ndim != 1:
@@ -135,16 +129,13 @@ class MarginalInverseWishart(regularizers.Regularizer):
         Error added to the correlations.
     n_channels : int
         Number of channels of the correlation matrices.
-    n_batches : int
-        Number of batches in the data.
     """
 
-    def __init__(self, nu, epsilon, n_channels, n_batches, **kwargs):
+    def __init__(self, nu, epsilon, n_channels, **kwargs):
         super().__init__(**kwargs)
         self.nu = nu
         self.epsilon = epsilon
         self.n_channels = n_channels
-        self.n_batches = n_batches
         self.bijector = tfb.Chain(
             [tfb.CholeskyOuterProduct(), tfb.CorrelationCholesky()]
         )
@@ -178,16 +169,13 @@ class LogNormal(regularizers.Regularizer):
         Shape is (n_channels,). All entries must be positive.
     epsilon : float
         Error added to the standard deviations.
-    n_batches : int
-        Number of batches in the data.
     """
 
-    def __init__(self, mu, sigma, epsilon, n_batches, **kwargs):
+    def __init__(self, mu, sigma, epsilon, **kwargs):
         super().__init__(**kwargs)
         self.mu = mu
         self.sigma = sigma
         self.epsilon = epsilon
-        self.n_batches = n_batches
         self.bijector = tfb.Softplus()
 
         # Validation

--- a/osl_dynamics/models/hmm.py
+++ b/osl_dynamics/models/hmm.py
@@ -26,6 +26,7 @@ from osl_dynamics.inference.layers import (
     CovarianceMatricesLayer,
     DiagonalMatricesLayer,
     VectorsLayer,
+    ScalingFactorLayer,
 )
 from osl_dynamics.models import obs_mod
 from osl_dynamics.models.mod_base import BaseModelConfig, ModelBase
@@ -1437,6 +1438,10 @@ def _model_structure(config):
     )
     data, gamma = tf.split(inputs, [config.n_channels, config.n_states], axis=2)
 
+    # Scaling factor
+    scaling_factor_layer = ScalingFactorLayer(name="scaling_factor")
+    scaling_factor = scaling_factor_layer(data)
+
     # Definition of layers
     means_layer = VectorsLayer(
         config.n_states,
@@ -1471,8 +1476,8 @@ def _model_structure(config):
     )
 
     # Data flow
-    mu = means_layer(data)  # data not used
-    D = covs_layer(data)  # data not used
+    mu = means_layer(data, scaling_factor=scaling_factor)  # data not used
+    D = covs_layer(data, scaling_factor=scaling_factor)  # data not used
     ll_loss = ll_loss_layer([data, mu, D, gamma, None])
 
     return tf.keras.Model(inputs=inputs, outputs=[ll_loss], name="HMM")

--- a/osl_dynamics/models/mage.py
+++ b/osl_dynamics/models/mage.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from typing import Literal
 
 import numpy as np
+import tensorflow as tf
 from tensorflow.keras import layers, models, optimizers, utils
 from tqdm.auto import trange
 
@@ -22,6 +23,7 @@ from osl_dynamics.inference.layers import (
     MixVectorsLayer,
     ModelRNNLayer,
     VectorsLayer,
+    ScalingFactorLayer,
 )
 from osl_dynamics.models import obs_mod
 from osl_dynamics.models.mod_base import BaseModelConfig, ModelBase
@@ -104,6 +106,12 @@ class Config(BaseModelConfig):
         Error added to mode stds for numerical stability.
     fcs_epsilon : float
         Error added to mode fcs for numerical stability.
+    means_regularizer : tf.keras.regularizers.Regularizer
+        Regularizer for the mean vectors.
+    stds_regularizer : tf.keras.regularizers.Regularizer
+        Regularizer for the standard deviation vectors.
+    fcs_regularizer : tf.keras.regularizers.Regularizer
+        Regularizer for the correlation matrices.
 
     batch_size : int
         Mini-batch size.
@@ -157,6 +165,9 @@ class Config(BaseModelConfig):
     initial_fcs: np.ndarray = None
     stds_epsilon: float = None
     fcs_epsilon: float = None
+    means_regularizer: tf.keras.regularizers.Regularizer = None
+    stds_regularizer: tf.keras.regularizers.Regularizer = None
+    fcs_regularizer: tf.keras.regularizers.Regularizer = None
     multiple_dynamics: bool = True
 
     def __post_init__(self):
@@ -634,6 +645,11 @@ def _build_inference_model(config):
     inputs = layers.Input(
         shape=(config.sequence_length, config.n_channels), name="data"
     )
+
+    # Scaling factor
+    scaling_factor_layer = ScalingFactorLayer(name="scaling_factor")
+    scaling_factor = scaling_factor_layer(inputs)
+
     data_drop_layer = layers.TimeDistributed(
         layers.Dropout(config.inference_dropout, name="inf_data_drop")
     )
@@ -674,6 +690,7 @@ def _build_inference_model(config):
         config.n_channels,
         config.learn_means,
         config.initial_means,
+        config.means_regularizer,
         name="means",
     )
 
@@ -683,6 +700,7 @@ def _build_inference_model(config):
         config.learn_stds,
         config.initial_stds,
         config.stds_epsilon,
+        config.stds_regularizer,
         name="stds",
     )
 
@@ -692,6 +710,7 @@ def _build_inference_model(config):
         config.learn_fcs,
         config.initial_fcs,
         config.fcs_epsilon,
+        config.fcs_regularizer,
         name="fcs",
     )
 
@@ -702,9 +721,9 @@ def _build_inference_model(config):
     concat_means_covs_layer = ConcatVectorsMatricesLayer(name="concat_means_covs")
 
     # Data flow
-    mu = means_layer(inputs)  # inputs not used
-    E = stds_layer(inputs)  # inputs not used
-    D = fcs_layer(inputs)  # inputs not used
+    mu = means_layer(inputs, scaling_factor=scaling_factor)  # inputs not used
+    E = stds_layer(inputs, scaling_factor=scaling_factor)  # inputs not used
+    D = fcs_layer(inputs, scaling_factor=scaling_factor)  # inputs not used
 
     m = mix_means_layer([alpha, mu])
     G = mix_stds_layer([alpha, E])

--- a/osl_dynamics/models/mdynemo.py
+++ b/osl_dynamics/models/mdynemo.py
@@ -27,6 +27,7 @@ from osl_dynamics.inference.layers import (
     SampleNormalDistributionLayer,
     SoftmaxLayer,
     VectorsLayer,
+    ScalingFactorLayer,
 )
 from osl_dynamics.models import obs_mod
 from osl_dynamics.models.inf_mod_base import (
@@ -496,6 +497,10 @@ def _model_structure(config):
         shape=(config.sequence_length, config.n_channels), name="data"
     )
 
+    # Scaling factor
+    scaling_factor_layer = ScalingFactorLayer(name="scaling_factor")
+    scaling_factor = scaling_factor_layer(inputs)
+
     #
     # Inference RNN
     #
@@ -613,9 +618,9 @@ def _model_structure(config):
     )
 
     # Data flow
-    mu = means_layer(inputs)  # inputs not used
-    E = stds_layer(inputs)  # inputs not used
-    D = fcs_layer(inputs)  # inputs not used
+    mu = means_layer(inputs, scaling_factor=scaling_factor)  # inputs not used
+    E = stds_layer(inputs, scaling_factor=scaling_factor)  # inputs not used
+    D = fcs_layer(inputs, scaling_factor=scaling_factor)  # inputs not used
 
     m = mix_means_layer([alpha, mu])
     G = mix_stds_layer([alpha, E])

--- a/osl_dynamics/models/mod_base.py
+++ b/osl_dynamics/models/mod_base.py
@@ -22,6 +22,7 @@ from tqdm.keras import TqdmCallback
 
 import osl_dynamics
 from osl_dynamics import data
+import osl_dynamics.data.tf as dtf
 from osl_dynamics.inference import callbacks, initializers
 from osl_dynamics.utils.misc import NumpyLoader, get_argument, replace_argument
 from osl_dynamics.utils.model import HTMLTable, LatexTable
@@ -232,6 +233,9 @@ class ModelBase:
         if use_tqdm:
             args, kwargs = replace_argument(self.model.fit, "verbose", 0, args, kwargs)
 
+        # Set the scaling factor for static quantity losses
+        self.set_scaling_factor(x)
+
         history = self.model.fit(*args, **kwargs)
         return history.history
 
@@ -435,6 +439,20 @@ class ModelBase:
         self.save_weights(
             f"{dirname}/weights"
         )  # will use the keras method: self.model.save_weights()
+
+    def set_scaling_factor(self, dataset):
+        """Set the scaling factor for static losses.
+
+        This assumes every model has a layer called "scaling_factor",
+        with an attribure called "n_batches".
+
+        Parameters
+        ----------
+        dataset : tensorflow.data.Dataset
+            TensorFlow dataset.
+        """
+        n_batches = dtf.get_n_batches(dataset)
+        self.model.get_layer("scaling_factor").n_batches = n_batches
 
     @contextmanager
     def set_trainable(self, layers, values):

--- a/osl_dynamics/models/sage.py
+++ b/osl_dynamics/models/sage.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from typing import Literal
 
 import numpy as np
+import tensorflow as tf
 from tensorflow.keras import layers, models, optimizers, utils
 from tqdm.auto import trange
 
@@ -20,6 +21,7 @@ from osl_dynamics.inference.layers import (
     MixVectorsLayer,
     ModelRNNLayer,
     VectorsLayer,
+    ScalingFactorLayer,
 )
 from osl_dynamics.models import obs_mod
 from osl_dynamics.models.mod_base import BaseModelConfig, ModelBase
@@ -99,6 +101,10 @@ class Config(BaseModelConfig):
         Initialisation for mode covariances.
     covariances_epsilon : float
         Error added to mode covariances for numerical stability.
+    means_regularizer : tf.keras.regularizers.Regularizer
+        Regularizer for mean vectors.
+    covariances_regularizer : tf.keras.regularizers.Regularizer
+        Regularizer for covariance matrices.
 
     batch_size : int
         Mini-batch size.
@@ -149,6 +155,8 @@ class Config(BaseModelConfig):
     initial_means: np.ndarray = None
     initial_covariances: np.ndarray = None
     covariances_epsilon: float = None
+    means_regularizer: tf.keras.regularizers.Regularizer = None
+    covariances_regularizer: tf.keras.regularizers.Regularizer = None
 
     def __post_init__(self):
         self.validate_dimension_parameters()
@@ -490,6 +498,11 @@ def _build_inference_model(config):
     inputs = layers.Input(
         shape=(config.sequence_length, config.n_channels), name="data"
     )
+
+    # Scaling factor
+    scaling_factor_layer = ScalingFactorLayer(name="scaling_factor")
+    scaling_factor = scaling_factor_layer(inputs)
+
     data_drop_layer = layers.TimeDistributed(
         layers.Dropout(config.inference_dropout, name="inf_data_drop")
     )
@@ -525,6 +538,7 @@ def _build_inference_model(config):
         config.n_channels,
         config.learn_means,
         config.initial_means,
+        config.means_regularizer,
         name="means",
     )
     covs_layer = CovarianceMatricesLayer(
@@ -533,6 +547,7 @@ def _build_inference_model(config):
         config.learn_covariances,
         config.initial_covariances,
         config.covariances_epsilon,
+        config.covariances_regularizer,
         name="covs",
     )
     mix_means_layer = MixVectorsLayer(name="mix_means")
@@ -540,8 +555,8 @@ def _build_inference_model(config):
     concat_means_covs_layer = ConcatVectorsMatricesLayer(name="concat_means_covs")
 
     # Data flow
-    mu = means_layer(inputs)  # inputs not used
-    D = covs_layer(inputs)  # inputs not used
+    mu = means_layer(inputs, scaling_factor=scaling_factor)  # inputs not used
+    D = covs_layer(inputs, scaling_factor=scaling_factor)  # inputs not used
     m = mix_means_layer([alpha, mu])
     C = mix_covs_layer([alpha, D])
     C_m = concat_means_covs_layer([m, C])

--- a/osl_dynamics/models/sedynemo.py
+++ b/osl_dynamics/models/sedynemo.py
@@ -37,6 +37,7 @@ from osl_dynamics.inference.layers import (
     StaticKLDivergenceLayer,
     MultiLayerPerceptronLayer,
     LearnableTensorLayer,
+    ScalingFactorLayer,
 )
 
 
@@ -260,12 +261,6 @@ class Model(VariationalInferenceModelBase):
     def make_dataset(self, inputs, **kwargs):
         """SE-DyNeMo requires subject id to be included in the dataset."""
         return super().make_dataset(inputs, subj_id=True, **kwargs)
-
-    def fit(self, training_data, *args, **kwargs):
-        # Set the scalings
-        self.set_dev_mlp_reg_scaling(training_data)
-        self.set_bayesian_kl_scaling(training_data)
-        return super().fit(training_data, *args, **kwargs)
 
     def get_group_means(self):
         """Get the group level mode means.
@@ -497,6 +492,10 @@ def _model_structure(config):
     data = layers.Input(shape=(config.sequence_length, config.n_channels), name="data")
     subj_id = layers.Input(shape=(config.sequence_length,), name="subj_id")
 
+    # Scaling factor
+    scaling_factor_layer = ScalingFactorLayer(name="scaling_factor")
+    scaling_factor = scaling_factor_layer(data)
+
     # Inference RNN:
     # Layer definitions
     inference_input_dropout_layer = layers.Dropout(
@@ -567,8 +566,8 @@ def _model_structure(config):
     subjects = subjects_layer(data)
     subject_embeddings = subject_embeddings_layer(subjects)
 
-    group_mu = group_means_layer(data)
-    group_D = group_covs_layer(data)
+    group_mu = group_means_layer(data, scaling_factor=scaling_factor)
+    group_D = group_covs_layer(data, scaling_factor=scaling_factor)
 
     # ---------------
     # Mean deviations
@@ -632,7 +631,9 @@ def _model_structure(config):
         )
 
         # Get the mean deviation maps (no global magnitude information)
-        means_dev_map_input = means_dev_map_input_layer([data, means_concat_embeddings])
+        means_dev_map_input = means_dev_map_input_layer(
+            means_concat_embeddings, scaling_factor=scaling_factor
+        )
         means_dev_map = means_dev_map_layer(means_dev_map_input)
         norm_means_dev_map = norm_means_dev_map_layer(means_dev_map)
 
@@ -721,7 +722,9 @@ def _model_structure(config):
         )
 
         # Get the covariance deviation maps (no global magnitude information)
-        covs_dev_map_input = covs_dev_map_input_layer([data, covs_concat_embeddings])
+        covs_dev_map_input = covs_dev_map_input_layer(
+            covs_concat_embeddings, scaling_factor=scaling_factor
+        )
         covs_dev_map = covs_dev_map_layer(covs_dev_map_input)
         norm_covs_dev_map = norm_covs_dev_map_layer(covs_dev_map)
 
@@ -832,7 +835,7 @@ def _model_structure(config):
 
         # Data flow
         means_dev_mag_mod_beta_input = means_dev_mag_mod_beta_input_layer(
-            [data, means_concat_embeddings]
+            means_concat_embeddings, scaling_factor=scaling_factor
         )
         means_dev_mag_mod_beta = means_dev_mag_mod_beta_layer(
             means_dev_mag_mod_beta_input
@@ -843,7 +846,8 @@ def _model_structure(config):
                 means_dev_mag_inf_alpha,
                 means_dev_mag_inf_beta,
                 means_dev_mag_mod_beta,
-            ]
+            ],
+            scaling_factor=scaling_factor,
         )
     else:
         means_dev_mag_kl_loss_layer = ZeroLayer((), name="means_dev_mag_kl_loss")
@@ -873,7 +877,7 @@ def _model_structure(config):
 
         # Data flow
         covs_dev_mag_mod_beta_input = covs_dev_mag_mod_beta_input_layer(
-            [data, covs_concat_embeddings]
+            covs_concat_embeddings, scaling_factor=scaling_factor
         )
         covs_dev_mag_mod_beta = covs_dev_mag_mod_beta_layer(covs_dev_mag_mod_beta_input)
         covs_dev_mag_kl_loss = covs_dev_mag_kl_loss_layer(
@@ -882,7 +886,8 @@ def _model_structure(config):
                 covs_dev_mag_inf_alpha,
                 covs_dev_mag_inf_beta,
                 covs_dev_mag_mod_beta,
-            ]
+            ],
+            scaling_factor=scaling_factor,
         )
     else:
         covs_dev_mag_kl_loss_layer = ZeroLayer((), name="covs_dev_mag_kl_loss")

--- a/osl_dynamics/models/sehmm.py
+++ b/osl_dynamics/models/sehmm.py
@@ -27,6 +27,7 @@ from osl_dynamics.inference.layers import (
     StaticKLDivergenceLayer,
     KLLossLayer,
     MultiLayerPerceptronLayer,
+    ScalingFactorLayer,
 )
 from osl_dynamics.models.hmm import Config as HMMConfig, Model as HMMModel
 from osl_dynamics.models import obs_mod
@@ -833,6 +834,10 @@ def _model_structure(config):
     )
     subj_id = tf.squeeze(subj_id, axis=2)
 
+    # Scaling factor
+    scaling_factor_layer = ScalingFactorLayer(name="scaling_factor")
+    scaling_factor = scaling_factor_layer(data)
+
     # Subject embedding layers
     subjects_layer = TFRangeLayer(config.n_subjects, name="subjects")
     subject_embeddings_layer = layers.Embedding(
@@ -861,8 +866,8 @@ def _model_structure(config):
     subjects = subjects_layer(data)
     subject_embeddings = subject_embeddings_layer(subjects)
 
-    group_mu = group_means_layer(data)
-    group_D = group_covs_layer(data)
+    group_mu = group_means_layer(data, scaling_factor=scaling_factor)
+    group_D = group_covs_layer(data, scaling_factor=scaling_factor)
 
     # ---------------
     # Mean deviations
@@ -925,7 +930,9 @@ def _model_structure(config):
         )
 
         # Get the mean deviation maps (no global magnitude information)
-        means_dev_map_input = means_dev_map_input_layer([data, means_concat_embeddings])
+        means_dev_map_input = means_dev_map_input_layer(
+            means_concat_embeddings, scaling_factor=scaling_factor
+        )
         means_dev_map = means_dev_map_layer(means_dev_map_input)
         norm_means_dev_map = norm_means_dev_map_layer(means_dev_map)
 
@@ -1014,7 +1021,9 @@ def _model_structure(config):
         )
 
         # Get the covariance deviation maps (no global magnitude information)
-        covs_dev_map_input = covs_dev_map_input_layer([data, covs_concat_embeddings])
+        covs_dev_map_input = covs_dev_map_input_layer(
+            covs_concat_embeddings, scaling_factor=scaling_factor
+        )
         covs_dev_map = covs_dev_map_layer(covs_dev_map_input)
         norm_covs_dev_map = norm_covs_dev_map_layer(covs_dev_map)
 
@@ -1095,7 +1104,7 @@ def _model_structure(config):
 
         # Data flow
         means_dev_mag_mod_beta_input = means_dev_mag_mod_beta_input_layer(
-            [data, means_concat_embeddings]
+            means_concat_embeddings, scaling_factor=scaling_factor
         )
         means_dev_mag_mod_beta = means_dev_mag_mod_beta_layer(
             means_dev_mag_mod_beta_input
@@ -1106,7 +1115,8 @@ def _model_structure(config):
                 means_dev_mag_inf_alpha,
                 means_dev_mag_inf_beta,
                 means_dev_mag_mod_beta,
-            ]
+            ],
+            scaling_factor=scaling_factor,
         )
     else:
         means_dev_mag_kl_loss_layer = ZeroLayer((), name="means_dev_mag_kl_loss")
@@ -1136,7 +1146,7 @@ def _model_structure(config):
 
         # Data flow
         covs_dev_mag_mod_beta_input = covs_dev_mag_mod_beta_input_layer(
-            [data, covs_concat_embeddings]
+            covs_concat_embeddings, scaling_factor=scaling_factor
         )
         covs_dev_mag_mod_beta = covs_dev_mag_mod_beta_layer(covs_dev_mag_mod_beta_input)
         covs_dev_mag_kl_loss = covs_dev_mag_kl_loss_layer(
@@ -1145,7 +1155,8 @@ def _model_structure(config):
                 covs_dev_mag_inf_alpha,
                 covs_dev_mag_inf_beta,
                 covs_dev_mag_mod_beta,
-            ]
+            ],
+            scaling_factor=scaling_factor,
         )
     else:
         covs_dev_mag_kl_loss_layer = ZeroLayer((), name="covs_dev_mag_kl_loss")

--- a/osl_dynamics/models/state_dynemo.py
+++ b/osl_dynamics/models/state_dynemo.py
@@ -22,6 +22,7 @@ from osl_dynamics.inference.layers import (
     SampleOneHotCategoricalDistributionLayer,
     SoftmaxLayer,
     VectorsLayer,
+    ScalingFactorLayer,
 )
 from osl_dynamics.models.dynemo import Model as DyNeMo
 from osl_dynamics.models.inf_mod_base import VariationalInferenceModelConfig
@@ -312,6 +313,10 @@ def _model_structure(config):
     # Layer for input
     data = layers.Input(shape=(config.sequence_length, config.n_channels), name="data")
 
+    # Scaling factor
+    scaling_factor_layer = ScalingFactorLayer(name="scaling_factor")
+    scaling_factor = scaling_factor_layer(data)
+
     # Inference RNN:
     # - q(state_t) = softmax(theta_t), where theta_t is a set of logits
     inf_rnn_layer = InferenceRNNLayer(
@@ -370,8 +375,8 @@ def _model_structure(config):
         config.n_states, config.covariances_epsilon, name="ll_loss"
     )
 
-    mu = means_layer(data)  # data not used
-    D = covs_layer(data)  # data not used
+    mu = means_layer(data, scaling_factor=scaling_factor)  # data not used
+    D = covs_layer(data, scaling_factor=scaling_factor)  # data not used
     ll_loss = ll_loss_layer([data, mu, D, alpha, None])
 
     # Model RNN:


### PR DESCRIPTION
The way we scale the losses related to static quantities (KL losses of deviation magnitudes in subject embedding models, regularisation of observation model parameters) is refactored.

- There's no more confusing `n_batches` attribute in regularizers.
- Removed methods `obs.set_bayesian_kl_scaling` and `obs.set_dev_mlp_reg_scaling`.
- Every model has a layer for calculating the scaling factor called `scaling_factor`
- the `scaling_factor` layer is set by `mod_base.set_scaling_factor` and this will be done automatically for all models when fitting a model [https://github.com/OHBA-analysis/osl-dynamics/blob/5a3e58b7e349c68bc93a39a58acd2fa2e892db5b/osl_dynamics/models/mod_base.py#L237](url)
- No more confusing `data, inputs = inputs` in the call method in the `MultiLayerPerceptronLayer` class. 

This closes #138 .