### PR TITLE
Separate method to get instantaneous covariances.

### DIFF
--- a/osl_dynamics/simulation/hmm.py
+++ b/osl_dynamics/simulation/hmm.py
@@ -321,7 +321,6 @@ class HMM_MVN(Simulation):
             np.newaxis, ...
         ]
         self.obs_mod.covariances /= np.outer(sigma, sigma)[np.newaxis, ...]
-        self.obs_mod.instantaneous_covs /= np.outer(sigma, sigma)[np.newaxis, ...]
 
 
 class MDyn_HMM_MVN(Simulation):
@@ -416,7 +415,6 @@ class MDyn_HMM_MVN(Simulation):
 
         # Simulate data
         self.time_series = self.obs_mod.simulate_data(self.state_time_course)
-        self.instantaneous_covs = self.obs_mod.instantaneous_covs
 
     @property
     def n_modes(self):
@@ -440,7 +438,6 @@ class MDyn_HMM_MVN(Simulation):
             np.newaxis, ...
         ]
         self.obs_mod.stds /= sigma[np.newaxis, ...]
-        self.obs_mod.instantaneous_covs /= np.outer(sigma, sigma)[np.newaxis, ...]
 
 
 class MSubj_HMM_MVN(Simulation):
@@ -600,9 +597,6 @@ class MSubj_HMM_MVN(Simulation):
             self.obs_mod.subject_means - mu[:, np.newaxis, :]
         ) / sigma[:, np.newaxis, :]
         self.obs_mod.subject_covariances /= np.expand_dims(
-            sigma[:, :, np.newaxis] @ sigma[:, np.newaxis, :], 1
-        )
-        self.obs_mod.instantaneous_covs /= np.expand_dims(
             sigma[:, :, np.newaxis] @ sigma[:, np.newaxis, :], 1
         )
 
@@ -782,4 +776,3 @@ class HierarchicalHMM_MVN(Simulation):
         sigma = np.std(self.time_series, axis=0).astype(np.float64)
         super().standardize()
         self.obs_mod.covariances /= np.outer(sigma, sigma)[np.newaxis, ...]
-        self.obs_mod.instantaneous_covs /= np.outer(sigma, sigma)[np.newaxis, ...]

--- a/osl_dynamics/simulation/hmm.py
+++ b/osl_dynamics/simulation/hmm.py
@@ -313,6 +313,17 @@ class HMM_MVN(Simulation):
         else:
             raise AttributeError(f"No attribute called {attr}.")
 
+    def get_instantaneous_covariances(self):
+        """Get the ground truth covariances at each time point.
+
+        Returns
+        -------
+        inst_covs : np.ndarray
+            Instantaneous covariances.
+            Shape is (n_samples, n_channels, n_channels).
+        """
+        return self.obs_mod.get_instantaneous_covariances(self.state_time_course)
+
     def standardize(self):
         mu = np.mean(self.time_series, axis=0).astype(np.float64)
         sigma = np.std(self.time_series, axis=0).astype(np.float64)
@@ -429,6 +440,16 @@ class MDyn_HMM_MVN(Simulation):
             return getattr(self.obs_mod, attr)
         else:
             raise AttributeError(f"No attribute called {attr}.")
+
+        """Get the ground truth covariances at each time point.
+        
+        Returns
+        -------
+        inst_covs : np.ndarray
+            Instantaneous covariances.
+            Shape is (n_samples, n_channels, n_channels).
+        """
+        return self.obs_mod.get_instantaneous_covariances(self.state_time_course)
 
     def standardize(self):
         mu = np.mean(self.time_series, axis=0).astype(np.float64)
@@ -588,6 +609,17 @@ class MSubj_HMM_MVN(Simulation):
             return getattr(self.obs_mod, attr)
         else:
             raise AttributeError(f"No attribute called {attr}.")
+
+    def get_instantaneous_covariances(self):
+        """Get the ground truth covariances at each time point.
+
+        Returns
+        -------
+        inst_covs : np.ndarray
+            Instantaneous covariances.
+            Shape is (n_samples, n_channels, n_channels).
+        """
+        return self.obs_mod.get_instantaneous_covariances(self.state_time_course)
 
     def standardize(self):
         mu = np.mean(self.time_series, axis=1).astype(np.float64)

--- a/osl_dynamics/simulation/sm.py
+++ b/osl_dynamics/simulation/sm.py
@@ -173,13 +173,10 @@ class MixedSine_MVN(Simulation):
         mu = np.mean(self.time_series, axis=0).astype(np.float64)
         sigma = np.std(self.time_series, axis=0).astype(np.float64)
         super().standardize()
-        # TODO: need to double check this is the correct normalisation to
-        # apply when using a soft mixture simulation
         self.obs_mod.means = (self.obs_mod.means - mu[np.newaxis, ...]) / sigma[
             np.newaxis, ...
         ]
         self.obs_mod.covariances /= np.outer(sigma, sigma)[np.newaxis, ...]
-        self.obs_mod.instantaneous_covs /= np.outer(sigma, sigma)[np.newaxis, ...]
 
 
 class MSubj_MixedSine_MVN(Simulation):
@@ -314,10 +311,6 @@ class MSubj_MixedSine_MVN(Simulation):
             self.obs_mod.subject_means - means[:, None, :]
         ) / standard_deviations[:, None, :]
         self.obs_mod.subject_covariances /= np.expand_dims(
-            standard_deviations[:, :, None] @ standard_deviations[:, None, :],
-            axis=1,
-        )
-        self.obs_mod.instantaneous_covs /= np.expand_dims(
             standard_deviations[:, :, None] @ standard_deviations[:, None, :],
             axis=1,
         )


### PR DESCRIPTION
Previously we simulated instantaneous covariance when we generate data in `HMM_MVN`, `MixedSine_MVN`, etc simulations. This is memory inefficient because most examples don't use the instantaneous covariances.

Here, we separate the generation of the instantaneous covariances into a separate method.

I removed the normalisation of the instantaneous covariances from the `.standardize` method. Because `.get_instantaneous_covariances` the method will use the latest covariances, which will be standardized if we called `.standardize`.