### PR TITLE
Refact/dataset

### DIFF
--- a/osl_dynamics/data/base.py
+++ b/osl_dynamics/data/base.py
@@ -958,7 +958,6 @@ class Data:
         shuffle=True,
         validation_split=None,
         concatenate=True,
-        array_id=True,
         step_size=None,
     ):
         """Create a Tensorflow Dataset for training or evaluation.
@@ -976,9 +975,6 @@ class Data:
             Ratio to split the dataset into a training and validation set.
         concatenate : bool, optional
             Should we concatenate the datasets for each array?
-        array_id : bool, optional
-            Should we include the array id in the dataset? This argument can
-            be used to prepare datasets for subject-specific models.
         step_size : int, optional
             Number of samples to slide the sequence across the dataset.
             Default is no overlap.
@@ -1005,13 +1001,9 @@ class Data:
             # length
             array = self.arrays[i][: n_sequences[i] * sequence_length]
 
-            if array_id:
-                # Dataset with the time series data and ID
-                array_tracker = np.zeros(array.shape[0], dtype=np.float32) + i
-                data = {"data": array, "array_id": array_tracker}
-            else:
-                # Dataset with just the time series data
-                data = {"data": array}
+            # Dataset with the time series data and ID
+            array_tracker = np.zeros(array.shape[0], dtype=np.float32) + i
+            data = {"data": array, "array_id": array_tracker}
 
             # Create dataset
             dataset = dtf.create_dataset(
@@ -1113,7 +1105,6 @@ class Data:
         shuffle=True,
         validation_split=None,
         concatenate=True,
-        array_id=True,
         step_size=None,
     ):
         """Create a TFRecord Dataset for training or evaluation.
@@ -1130,9 +1121,6 @@ class Data:
             Ratio to split the dataset into a training and validation set.
         concatenate : bool, optional
             Should we concatenate the datasets for each array?
-        array_id : bool, optional
-            Should we include the subject id in the dataset? This argument can be
-            used to prepare datasets for subject-specific models.
         step_size : int, optional
             Number of samples to slide the sequence across the dataset.
             Default is no overlap.
@@ -1175,13 +1163,9 @@ class Data:
             # sequence length
             array = self.arrays[i][: n_sequences[i] * sequence_length]
 
-            if array_id:
-                # Create a dataset with the time series data and ID
-                array_tracker = np.zeros(array.shape[0], dtype=np.float32) + i
-                data = {"data": array, "array_id": array_tracker}
-            else:
-                # Create a dataset with just the time series data
-                data = {"data": array}
+            # Create a dataset with the time series data and ID
+            array_tracker = np.zeros(array.shape[0], dtype=np.float32) + i
+            data = {"data": array, "array_id": array_tracker}
 
             # Save the dataset
             dtf.save_tfrecord(
@@ -1204,7 +1188,7 @@ class Data:
 
         # Helper function for parsing training examples
         def _parse_example(example):
-            feature_names = ["data", "array_id"] if array_id else ["data"]
+            feature_names = ["data", "array_id"]
             feature_description = {
                 name: tf.io.FixedLenFeature([], tf.string) for name in feature_names
             }

--- a/osl_dynamics/data/base.py
+++ b/osl_dynamics/data/base.py
@@ -958,7 +958,7 @@ class Data:
         shuffle=True,
         validation_split=None,
         concatenate=True,
-        subj_id=False,
+        array_id=True,
         step_size=None,
     ):
         """Create a Tensorflow Dataset for training or evaluation.
@@ -976,8 +976,8 @@ class Data:
             Ratio to split the dataset into a training and validation set.
         concatenate : bool, optional
             Should we concatenate the datasets for each array?
-        subj_id : bool, optional
-            Should we include the subject id in the dataset? This argument can
+        array_id : bool, optional
+            Should we include the array id in the dataset? This argument can
             be used to prepare datasets for subject-specific models.
         step_size : int, optional
             Number of samples to slide the sequence across the dataset.
@@ -1005,10 +1005,10 @@ class Data:
             # length
             array = self.arrays[i][: n_sequences[i] * sequence_length]
 
-            if subj_id:
+            if array_id:
                 # Dataset with the time series data and ID
                 array_tracker = np.zeros(array.shape[0], dtype=np.float32) + i
-                data = {"data": array, "subj_id": array_tracker}
+                data = {"data": array, "array_id": array_tracker}
             else:
                 # Dataset with just the time series data
                 data = {"data": array}
@@ -1113,7 +1113,7 @@ class Data:
         shuffle=True,
         validation_split=None,
         concatenate=True,
-        subj_id=False,
+        array_id=True,
         step_size=None,
     ):
         """Create a TFRecord Dataset for training or evaluation.
@@ -1130,7 +1130,7 @@ class Data:
             Ratio to split the dataset into a training and validation set.
         concatenate : bool, optional
             Should we concatenate the datasets for each array?
-        subj_id : bool, optional
+        array_id : bool, optional
             Should we include the subject id in the dataset? This argument can be
             used to prepare datasets for subject-specific models.
         step_size : int, optional
@@ -1175,10 +1175,10 @@ class Data:
             # sequence length
             array = self.arrays[i][: n_sequences[i] * sequence_length]
 
-            if subj_id:
+            if array_id:
                 # Create a dataset with the time series data and ID
                 array_tracker = np.zeros(array.shape[0], dtype=np.float32) + i
-                data = {"data": array, "subj_id": array_tracker}
+                data = {"data": array, "array_id": array_tracker}
             else:
                 # Create a dataset with just the time series data
                 data = {"data": array}
@@ -1204,7 +1204,7 @@ class Data:
 
         # Helper function for parsing training examples
         def _parse_example(example):
-            feature_names = ["data", "subj_id"] if subj_id else ["data"]
+            feature_names = ["data", "array_id"] if array_id else ["data"]
             feature_description = {
                 name: tf.io.FixedLenFeature([], tf.string) for name in feature_names
             }

--- a/osl_dynamics/models/mod_base.py
+++ b/osl_dynamics/models/mod_base.py
@@ -271,7 +271,7 @@ class ModelBase:
         inputs,
         shuffle=False,
         concatenate=False,
-        subj_id=False,
+        array_id=True,
         step_size=None,
     ):
         """Converts a Data object into a TensorFlow Dataset.
@@ -285,8 +285,8 @@ class ModelBase:
             Should we shuffle the data?
         concatenate : bool, optional
             Should we return a single TensorFlow Dataset or a list of Datasets.
-        subj_id : bool, optional
-            Should we include the subject id in the dataset?
+        array_id : bool, optional
+            Should we include the array id in the dataset?
         step_size : int, optional
             Number of samples to slide the sequence across the dataset.
             Default is no overlap.
@@ -310,7 +310,7 @@ class ModelBase:
                     self.config.batch_size,
                     shuffle=shuffle,
                     concatenate=concatenate,
-                    subj_id=subj_id,
+                    array_id=array_id,
                     step_size=step_size,
                 )
             else:
@@ -319,7 +319,7 @@ class ModelBase:
                     self.config.batch_size,
                     shuffle=shuffle,
                     concatenate=concatenate,
-                    subj_id=subj_id,
+                    array_id=array_id,
                     step_size=step_size,
                 )
         elif isinstance(inputs, Dataset) and not concatenate:

--- a/osl_dynamics/models/mod_base.py
+++ b/osl_dynamics/models/mod_base.py
@@ -271,7 +271,6 @@ class ModelBase:
         inputs,
         shuffle=False,
         concatenate=False,
-        array_id=True,
         step_size=None,
     ):
         """Converts a Data object into a TensorFlow Dataset.
@@ -285,8 +284,6 @@ class ModelBase:
             Should we shuffle the data?
         concatenate : bool, optional
             Should we return a single TensorFlow Dataset or a list of Datasets.
-        array_id : bool, optional
-            Should we include the array id in the dataset?
         step_size : int, optional
             Number of samples to slide the sequence across the dataset.
             Default is no overlap.
@@ -310,7 +307,6 @@ class ModelBase:
                     self.config.batch_size,
                     shuffle=shuffle,
                     concatenate=concatenate,
-                    array_id=array_id,
                     step_size=step_size,
                 )
             else:
@@ -319,7 +315,6 @@ class ModelBase:
                     self.config.batch_size,
                     shuffle=shuffle,
                     concatenate=concatenate,
-                    array_id=array_id,
                     step_size=step_size,
                 )
         elif isinstance(inputs, Dataset) and not concatenate:

--- a/osl_dynamics/models/sedynemo.py
+++ b/osl_dynamics/models/sedynemo.py
@@ -360,7 +360,8 @@ class Model(VariationalInferenceModelBase):
             Training dataset.
         """
         training_dataset = self.make_dataset(
-            training_dataset, concatenate=True, array_id=True
+            training_dataset,
+            concatenate=True,
         )
 
         if self.config.learn_means:

--- a/osl_dynamics/models/sehmm.py
+++ b/osl_dynamics/models/sehmm.py
@@ -258,7 +258,9 @@ class Model(HMMModel):
 
         # Make a TensorFlow dataset
         dataset = self.make_dataset(
-            dataset, shuffle=True, concatenate=True, array_id=True
+            dataset,
+            shuffle=True,
+            concatenate=True,
         )
 
         # Set static loss scaling factor
@@ -409,7 +411,6 @@ class Model(HMMModel):
         training_data = self.make_dataset(
             training_data,
             concatenate=True,
-            array_id=True,
         )
 
         return super().random_subset_initialization(
@@ -444,7 +445,8 @@ class Model(HMMModel):
         """
         # Make a TensorFlow Dataset
         training_dataset = self.make_dataset(
-            training_data, concatenate=True, array_id=True
+            training_data,
+            concatenate=True,
         )
 
         return super().random_state_time_course_initialization(
@@ -655,7 +657,8 @@ class Model(HMMModel):
             Training dataset.
         """
         training_dataset = self.make_dataset(
-            training_dataset, concatenate=True, array_id=True
+            training_dataset,
+            concatenate=True,
         )
 
         if self.config.learn_means:
@@ -694,7 +697,10 @@ class Model(HMMModel):
         _logger.info("Getting free energy")
 
         # Convert to a TensorFlow dataset if not already
-        dataset = self.make_dataset(dataset, concatenate=True, array_id=True)
+        dataset = self.make_dataset(
+            dataset,
+            concatenate=True,
+        )
 
         # Calculate variational free energy for each batch
         free_energy = []
@@ -741,7 +747,10 @@ class Model(HMMModel):
             Model evidence.
         """
         _logger.info("Getting model evidence")
-        dataset = self.make_dataset(dataset, concatenate=True, array_id=True)
+        dataset = self.make_dataset(
+            dataset,
+            concatenate=True,
+        )
         n_batches = dtf.get_n_batches(dataset)
 
         evidence = 0
@@ -797,7 +806,7 @@ class Model(HMMModel):
             State probabilities with shape (n_subjects, n_samples, n_states)
             or (n_samples, n_states).
         """
-        dataset = self.make_dataset(dataset, array_id=True)
+        dataset = self.make_dataset(dataset)
 
         _logger.info("Getting alpha")
         alpha = []


### PR DESCRIPTION
- `subj_id` is renamed to `array_id` for better consistency.
- `array_id` is always included in the dataset, which solves the bug when training both models that doesn't need `array_id` (e.g. DyNeMo) and models that need `array_id` (e.g. SE-DyNeMo) on the same tfrecord files, which won't be overwritten.