### PR TITLE
Fix: Importing `tensorflow` package for `Data.dataset` function

### DIFF
--- a/osl_dynamics/data/base.py
+++ b/osl_dynamics/data/base.py
@@ -991,6 +991,8 @@ class Data:
             Dataset for training or evaluating the model along with the
             validation set if :code:`validation_split` was passed.
         """
+        import tensorflow as tf  # moved here to avoid slow imports
+
         self.sequence_length = sequence_length
         self.batch_size = batch_size
         self.step_size = step_size or sequence_length


### PR DESCRIPTION
Following the recent [commit](ced2e1ffb46bf2304501b0c1635313e9952fdeae), the `dataset` function needs to import `tensorflow` package as done in `tfrecord_dataset` function to prevent errors.