### PR TITLE
Power normalisation fixes

### DIFF
--- a/osl_dynamics/analysis/power.py
+++ b/osl_dynamics/analysis/power.py
@@ -196,12 +196,12 @@ def variance_from_spectra(
         else:
             # Integrate over the given frequency range
             if frequency_range is None:
-                p = np.mean(psd, axis=-1)
+                p = np.sum(psd, axis=-1)
             else:
                 [f_min_arg, f_max_arg] = get_frequency_args_range(
                     frequencies, frequency_range
                 )
-                p = np.mean(psd[..., f_min_arg : f_max_arg + 1], axis=-1)
+                p = np.sum(psd[..., f_min_arg : f_max_arg + 1], axis=-1)
 
         p = p.reshape(n_components, n_modes, n_channels)
         var.append(p)

--- a/osl_dynamics/analysis/power.py
+++ b/osl_dynamics/analysis/power.py
@@ -198,10 +198,8 @@ def variance_from_spectra(
             if frequency_range is None:
                 p = np.sum(psd, axis=-1)
             else:
-                [f_min_arg, f_max_arg] = get_frequency_args_range(
-                    frequencies, frequency_range
-                )
-                p = np.sum(psd[..., f_min_arg : f_max_arg + 1], axis=-1)
+                [f_min, f_max] = get_frequency_args_range(frequencies, frequency_range)
+                p = np.sum(psd[..., f_min:f_max], axis=-1)
 
         p = p.reshape(n_components, n_modes, n_channels)
         var.append(p)


### PR DESCRIPTION
Changes:
- Fixed the calculation of the power (variance) from a PSD. [Switched from taking the mean to a summation.]
- Made sure the sum of power in different frequency bands gives the same power as the total frequency range.

I.e. in this PR we ensure:
```
power.variance_from_spectra(f, psd, frequency_range=[1,4])
+ power.variance_from_spectra(f, psd, frequency_range=[4,8])
```
gives the same power map as
```
power.variance_from_spectra(f, psd, frequency_range=[1,8])
```