### PR TITLE
SE-HMM (Baum-welch using float64)

### DIFF
--- a/examples/simulation/sehmm_hmm-mvn.py
+++ b/examples/simulation/sehmm_hmm-mvn.py
@@ -38,11 +38,7 @@ config = Config(
     learning_rate=1e-2,
     lr_decay=0.1,
     n_epochs=30,
-    learn_trans_prob=True,
-    do_kl_annealing=True,
-    kl_annealing_curve="tanh",
-    kl_annealing_sharpness=10,
-    n_kl_annealing_epochs=15,
+    learn_trans_prob=False,
 )
 
 # Simulate data

--- a/examples/simulation/sehmm_hmm-mvn.py
+++ b/examples/simulation/sehmm_hmm-mvn.py
@@ -34,11 +34,11 @@ config = Config(
     dev_regularizer_factor=10,
     learn_means=False,
     learn_covariances=True,
-    batch_size=64,
+    batch_size=128,
     learning_rate=1e-2,
-    lr_decay=0.1,
-    n_epochs=30,
-    learn_trans_prob=False,
+    lr_decay=0.05,
+    n_epochs=60,
+    learn_trans_prob=True,
 )
 
 # Simulate data
@@ -49,7 +49,7 @@ sim = simulation.MSubj_HMM_MVN(
     subject_covariances="random",
     n_states=config.n_states,
     n_channels=config.n_channels,
-    n_covariances_act=2,
+    n_covariances_act=5,
     n_subjects=config.n_subjects,
     n_subject_embedding_dim=config.subject_embeddings_dim,
     n_mode_embedding_dim=config.mode_embeddings_dim,

--- a/osl_dynamics/config_api/wrappers.py
+++ b/osl_dynamics/config_api/wrappers.py
@@ -323,6 +323,60 @@ def train_sehmm(
     fit_kwargs=None,
     save_inf_params=True,
 ):
+    """ Train a `Subject embedding Hidden Markov Model <https://osl-dynamics.\
+    readthedocs.io/en/latest/autoapi/osl_dynamics/models/sehmm/index.html>`_.
+    
+    This function will:
+
+    1. Build an :code:`sehmm.Model` object.
+    2. Initialize the parameters of the model using
+        :code:`Model.random_state_time_course_initialization`.
+    3. Perform full training.
+    4. Save the inferred parameters (state probabilities, means,
+        covariances and subject embeddings) if :code:`save_inf_params=True`.
+    
+    This function will create two directories:
+
+    - :code:`<output_dir>/model`, which contains the trained model.
+    - :code:`<output_dir>/inf_params`, which contains the inferred parameters.
+        This directory is only created if :code:`save_inf_params=True`.
+
+    Parameters
+    ----------
+    data : osl_dynamics.data.Data
+        Data object for training the model.
+    output_dir : str
+        Path to output directory.
+    config_kwargs : dict
+        Keyword arguments to pass to `sehmm.Config <https://osl-dynamics\
+        .readthedocs.io/en/latest/autoapi/osl_dynamics/models/sehmm/index.html\
+        #osl_dynamics.models.sehmm.Config>`_. Defaults to::
+
+            {
+                'sequence_length': 200,
+                'mode_embeddings_dim': 2,
+                'subject_embeddings_dim': 2,
+                'dev_n_layers': 5,
+                'dev_n_units': 32,
+                'dev_activation': 'tanh',
+                'dev_normalization': 'layer',
+                'dev_regularizer': 'l1',
+                'dev_regularizer_factor': 0.1,
+                'batch_size': 64,
+                'learning_rate': 0.01,
+                'lr_decay': 0.1,
+                'n_epochs': 20,
+            }.
+    init_kwargs : dict, optional
+        Keyword arguments to pass to
+        :code:`Model.random_state_time_course_initialization`. Defaults to::
+
+            {'n_init': 5, 'n_epochs': 2}.
+    fit_kwargs : dict, optional
+        Keyword arguments to pass to the :code:`Model.fit`. No defaults.
+    save_inf_params : bool, optional
+        Should we save the inferred parameters?
+    """
     if data is None:
         raise ValueError("data must be passed.")
 

--- a/osl_dynamics/inference/optimizers.py
+++ b/osl_dynamics/inference/optimizers.py
@@ -23,6 +23,7 @@ class ExponentialMovingAverage(optimizer_v2.OptimizerV2):
     @tf.function
     def _resource_apply_dense(self, grad, var):
         # grad should be the new value for var
+        grad = tf.cast(grad, var.dtype)
         return var.assign((1.0 - self.decay) * var + self.decay * grad)
 
 

--- a/osl_dynamics/models/inf_mod_base.py
+++ b/osl_dynamics/models/inf_mod_base.py
@@ -802,9 +802,6 @@ class MarkovStateInferenceModelBase(ModelBase):
         if lr_decay is None:
             lr_decay = self.config.lr_decay
 
-        if kl_annealing_callback is None:
-            kl_annealing_callback = self.config.do_kl_annealing
-
         def lr_scheduler(epoch, lr):
             return self.config.learning_rate * np.exp(-lr_decay * epoch)
 
@@ -827,24 +824,6 @@ class MarkovStateInferenceModelBase(ModelBase):
             kwargs,
             append=True,
         )
-
-        # KL annealing
-        if kl_annealing_callback:
-            kl_annealing_callback = callbacks.KLAnnealingCallback(
-                curve=self.config.kl_annealing_curve,
-                annealing_sharpness=self.config.kl_annealing_sharpness,
-                n_annealing_epochs=self.config.n_kl_annealing_epochs,
-            )
-
-            # Update arguments to pass to the fit method
-            args, kwargs = replace_argument(
-                self.model.fit,
-                "callbacks",
-                [kl_annealing_callback],
-                args,
-                kwargs,
-                append=True,
-            )
 
         return super().fit(*args, **kwargs)
 

--- a/osl_dynamics/models/sehmm.py
+++ b/osl_dynamics/models/sehmm.py
@@ -787,6 +787,7 @@ def _model_structure(config):
         config.n_states,
         config.initial_trans_prob,
         config.learn_trans_prob,
+        dtype="float64",
         name="hid_state_inf",
     )
     gamma, xi = hidden_state_inference_layer(ll)

--- a/osl_dynamics/models/sehmm.py
+++ b/osl_dynamics/models/sehmm.py
@@ -29,10 +29,12 @@ from osl_dynamics.inference.layers import (
 )
 from osl_dynamics.models import obs_mod
 from osl_dynamics.models.mod_base import BaseModelConfig
+from osl_dynamics.inference import callbacks
 from osl_dynamics.models.inf_mod_base import (
     MarkovStateInferenceModelConfig,
     MarkovStateInferenceModelBase,
 )
+from osl_dynamics.utils.misc import replace_argument
 
 _logger = logging.getLogger("osl-dynamics")
 
@@ -242,6 +244,47 @@ class Model(MarkovStateInferenceModelBase):
     def build_model(self):
         """Builds a keras model."""
         self.model = _model_structure(self.config)
+
+    def fit(self, *args, kl_annealing_callback=None, **kwargs):
+        """Wrapper for the standard keras fit method.
+
+        Parameters
+        ----------
+        *args : arguments
+            Arguments for :code:`MarkovStateInferenceModelBase.fit()`.
+        kl_annealing_callback : bool, optional
+            Should we update the KL annealing factor during training?
+        **kwargs : keyword arguments, optional
+            Keyword arguments for :code:`MarkovStateInferenceModelBase.fit()`.
+
+        Returns
+        -------
+        history : history
+            The training history.
+        """
+        # Callback for KL annealing
+        if kl_annealing_callback is None:
+            kl_annealing_callback = self.config.do_kl_annealing
+
+        # KL annealing
+        if kl_annealing_callback:
+            kl_annealing_callback = callbacks.KLAnnealingCallback(
+                curve=self.config.kl_annealing_curve,
+                annealing_sharpness=self.config.kl_annealing_sharpness,
+                n_annealing_epochs=self.config.n_kl_annealing_epochs,
+            )
+
+            # Update arguments to pass to the fit method
+            args, kwargs = replace_argument(
+                self.model.fit,
+                "callbacks",
+                [kl_annealing_callback],
+                args,
+                kwargs,
+                append=True,
+            )
+
+        return super().fit(*args, **kwargs)
 
     def reset_weights(self, keep=None):
         """Reset the model weights.


### PR DESCRIPTION
Use float64 for the baum-welch algorithm.

The default float32 is not accurate enough for the iterative baum-welch algorithm in SE-HMM and now the computation is all done in double precision for better numerical stability.