### PR TITLE
Bug: error in max-t permutation test

### DIFF
--- a/osl_dynamics/analysis/power.py
+++ b/osl_dynamics/analysis/power.py
@@ -375,6 +375,8 @@ def save(
     )
 
     if asymmetric_data is None:
+        vmin = None
+        vmax = None
         asymmetric_data = False
     elif isinstance(asymmetric_data, dict):
         # See if colorbar limits were passed

--- a/osl_dynamics/analysis/power.py
+++ b/osl_dynamics/analysis/power.py
@@ -376,7 +376,6 @@ def save(
 
     asymmetric_data = asymmetric_data or False
     if isinstance(asymmetric_data, dict):
-
         # See if colorbar limits were passed
         vmin = asymmetric_data.pop("vmin", None)
         vmax = asymmetric_data.pop("vmax", None)

--- a/osl_dynamics/analysis/statistics.py
+++ b/osl_dynamics/analysis/statistics.py
@@ -284,7 +284,7 @@ def group_diff_max_stat_perm(
         print("Using copes as metric")
         copes = abs(model.copes[0])
         percentiles = stats.percentileofscore(null_dist, copes)
-    pvalues = 1 - percentiles / 100
+    pvalues = (1 - percentiles / 100) * 2
 
     # Get group differences
     group_diff = model.copes[0]


### PR DESCRIPTION
In `osl-dynamics`, the max-t permutation test implemented in `group_diff_max_stat_perm` calculates p-values by
```
pvalues = 1 - percentiles / 100
```
In the function, while we're using a two-sided t-test, percentiles are computed from the absolute values of max-t distribution.

In a normal two-sided t-test, if we want to test the null hypothesis against an alpha threshold of 0.05, we would take values outside of 2.5 and 97.5 percentiles from the distribution to be significant. However, as we have transformed the distribution with `abs()` operation, if we take `pvalues` as above and use a threshold of 0.05 (i.e., `pvalues < 0.05`), we are essentially enforcing a threshold of 0.1. (For example, in the tutorial [here](https://osl-dynamics.readthedocs.io/en/latest/tutorials_build/hmm_summary_stats_analysis.html#comparing-groups).)

This was also the case with `glmtools` when I talked to Andrew.
```
alpha_thr = 100 - (0.05 / 2) * 100
threshold = perm.get_thresh(alpha_thr)
```
where `perm` is a glmtools permutation object and `get_threshold()` is essentially `np.nanpercentile(null_dist, alpha_thr, axis=0)`.

Therefore, alpha threshold should be divided by two or p-values multiplied by two to correct for the use of absolute distribution in conducting a two-sided t-test. I think the former is not ideal, as the users would be confused as they need to use 0.025 to test for 0.05.