### PR TITLE
Enhance: Updated SE-HMM (and SE-DyNeMo)

### DIFF
--- a/examples/simulation/sedynemo_hmm-mvn.py
+++ b/examples/simulation/sedynemo_hmm-mvn.py
@@ -82,6 +82,9 @@ model.summary()
 # Set regularizers
 model.set_regularizers(training_data)
 
+# Set dev parameters initializer
+model.set_dev_parameters_initializer(training_data)
+
 model.random_subset_initialization(training_data, n_init=5, n_epochs=3, take=0.4)
 
 print("Training model")
@@ -106,6 +109,8 @@ print("Fractional occupancies (DyNeMo):", modes.fractional_occupancies(inf_stc))
 # Plot the simulated and inferred subject embeddings with group labels
 sim_subject_embeddings = sim.subject_embeddings
 inf_subject_embeddings = model.get_subject_embeddings()
+inf_subject_embeddings -= np.mean(inf_subject_embeddings, axis=0)
+inf_subject_embeddings /= np.std(inf_subject_embeddings, axis=0)
 group_masks = [sim.assigned_groups == i for i in range(sim.n_groups)]
 
 fig, axes = plt.subplots(1, 2, figsize=(10, 5))

--- a/examples/simulation/sehmm_hmm-mvn.py
+++ b/examples/simulation/sehmm_hmm-mvn.py
@@ -33,11 +33,15 @@ config = Config(
     dev_regularizer_factor=10,
     learn_means=False,
     learn_covariances=True,
-    batch_size=128,
-    learning_rate=1e-2,
+    batch_size=64,
+    learning_rate=0.005,
     lr_decay=0.05,
-    n_epochs=60,
+    n_epochs=40,
     learn_trans_prob=True,
+    do_kl_annealing=True,
+    kl_annealing_curve="tanh",
+    kl_annealing_sharpness=10,
+    n_kl_annealing_epochs=20,
 )
 
 # Simulate data
@@ -71,7 +75,12 @@ model.summary()
 # Set regularizers
 model.set_regularizers(training_data)
 
-model.random_state_time_course_initialization(training_data, n_epochs=3, n_init=5)
+# Set dev parameters initializer
+model.set_dev_parameters_initializer(training_data)
+
+model.random_state_time_course_initialization(
+    training_data, n_epochs=3, n_init=5, take=1
+)
 # Train model
 history = model.fit(training_data)
 
@@ -112,7 +121,9 @@ print("Fractional occupancies (Inferred):", modes.fractional_occupancies(inf_stc
 
 
 sim_subject_embeddings = sim.subject_embeddings
-subject_embeddings = model.get_subject_embeddings()
+inf_subject_embeddings = model.get_subject_embeddings()
+inf_subject_embeddings -= np.mean(inf_subject_embeddings, axis=0)
+inf_subject_embeddings /= np.std(inf_subject_embeddings, axis=0)
 group_masks = [sim.assigned_groups == i for i in range(sim.n_groups)]
 
 fig, axes = plt.subplots(1, 2, figsize=(10, 5))
@@ -129,8 +140,8 @@ plotting.plot_scatter(
 )
 
 plotting.plot_scatter(
-    [subject_embeddings[group_mask, 0] for group_mask in group_masks],
-    [subject_embeddings[group_mask, 1] for group_mask in group_masks],
+    [inf_subject_embeddings[group_mask, 0] for group_mask in group_masks],
+    [inf_subject_embeddings[group_mask, 1] for group_mask in group_masks],
     x_label="dim_1",
     y_label="dim_2",
     annotate=[

--- a/osl_dynamics/config_api/wrappers.py
+++ b/osl_dynamics/config_api/wrappers.py
@@ -413,6 +413,9 @@ def train_sehmm(
     # Set regularisers
     model.set_regularizers(data)
 
+    # Set deviation initializer
+    model.set_dev_parameters_initializer(data)
+
     # Initialisation
     default_init_kwargs = {"n_init": 5, "n_epochs": 2}
     init_kwargs = override_dict_defaults(default_init_kwargs, init_kwargs)

--- a/osl_dynamics/inference/callbacks.py
+++ b/osl_dynamics/inference/callbacks.py
@@ -165,6 +165,15 @@ class KLAnnealingCallback(callbacks.Callback):
         kl_loss_layer = self.model.get_layer("kl_loss")
         kl_loss_layer.annealing_factor.assign(new_value)
 
+        # Annealing factor for gamma sampling
+        if "means_dev_mag" in self.model.layers:
+            means_dev_mag_layer = self.model.get_layer("means_dev_mag")
+            means_dev_mag_layer.annealing_factor.assign(new_value)
+
+        if "covs_dev_mag" in self.model.layers:
+            covs_dev_mag_layer = self.model.get_layer("covs_dev_mag")
+            covs_dev_mag_layer.annealing_factor.assign(new_value)
+
 
 class EMADecayCallback(callbacks.Callback):
     """Callback to update the decay rate in an Exponential Moving Average optimizer.

--- a/osl_dynamics/inference/initializers.py
+++ b/osl_dynamics/inference/initializers.py
@@ -31,6 +31,28 @@ class WeightInitializer(Initializer):
         return self.initial_value
 
 
+class RandomWeightInitializer(Initializer):
+    """Initialize weights to given value with random noise added.
+
+    Parameters
+    ----------
+    initial_value : np.ndarray
+        Value to initialise weights to. Note, the shape is not checked.
+    std : float
+        Standard deviation of the noise to add.
+    """
+
+    def __init__(self, initial_value, std):
+        self.initial_value = tf.cast(initial_value, tf.float32)
+        self.std = std
+
+    def __call__(self, shape, dtype=None):
+        e = initializers.TruncatedNormal(mean=0.0, stddev=self.std).__call__(
+            shape=shape, dtype=tf.float32
+        )
+        return self.initial_value + e
+
+
 class IdentityCholeskyInitializer(Initializer):
     """Initialize weights to a flattened cholesky factor of identity
     matrices."""

--- a/osl_dynamics/models/obs_mod.py
+++ b/osl_dynamics/models/obs_mod.py
@@ -113,7 +113,7 @@ def set_dev_parameters_initializer(
         static_means = np.array([np.mean(t, axis=0) for t in time_series])
         static_means_dev = np.abs(static_means - np.mean(static_means, axis=0))
         static_means_dev_mean = np.mean(static_means_dev, axis=1)
-        static_means_dev_var = np.var(static_means_dev, axis=1)
+        static_means_dev_var = static_means_dev_mean / 5
 
         means_alpha = tfp.math.softplus_inverse(
             np.square(static_means_dev_mean) / static_means_dev_var
@@ -137,7 +137,7 @@ def set_dev_parameters_initializer(
         ]
         static_cov_chol_dev = np.abs(static_cov_chol - np.mean(static_cov_chol, axis=0))
         static_cov_chol_dev_mean = np.mean(static_cov_chol_dev, axis=1)
-        static_cov_chol_dev_var = np.var(static_cov_chol_dev, axis=1)
+        static_cov_chol_dev_var = static_cov_chol_dev_mean / 5
 
         covs_alpha = tfp.math.softplus_inverse(
             np.square(static_cov_chol_dev_mean) / static_cov_chol_dev_var

--- a/osl_dynamics/models/sedynemo.py
+++ b/osl_dynamics/models/sedynemo.py
@@ -661,7 +661,7 @@ def _model_structure(config):
         )
 
         norm_means_dev_map_layer = layers.LayerNormalization(
-            axis=-1, name="norm_means_dev_map"
+            axis=-1, scale=False, name="norm_means_dev_map"
         )
 
         means_dev_mag_inf_alpha_input_layer = LearnableTensorLayer(
@@ -680,7 +680,7 @@ def _model_structure(config):
             shape=(config.n_subjects, config.n_modes, 1),
             learn=config.learn_means,
             initializer=osld_initializers.RandomWeightInitializer(
-                tfp.math.softplus_inverse(config.initial_dev.get("means_beta", 10.0)),
+                tfp.math.softplus_inverse(config.initial_dev.get("means_beta", 5.0)),
                 0.1,
             ),
             name="means_dev_mag_inf_beta_input",
@@ -689,7 +689,7 @@ def _model_structure(config):
             "softplus", name="means_dev_mag_inf_beta"
         )
         means_dev_mag_layer = SampleGammaDistributionLayer(
-            config.covariances_epsilon, name="means_dev_mag"
+            config.covariances_epsilon, config.do_kl_annealing, name="means_dev_mag"
         )
 
         means_dev_layer = layers.Multiply(name="means_dev")
@@ -760,7 +760,7 @@ def _model_structure(config):
             config.n_channels * (config.n_channels + 1) // 2, name="covs_dev_map"
         )
         norm_covs_dev_map_layer = layers.LayerNormalization(
-            axis=-1, name="norm_covs_dev_map"
+            axis=-1, scale=False, name="norm_covs_dev_map"
         )
 
         covs_dev_mag_inf_alpha_input_layer = LearnableTensorLayer(
@@ -779,7 +779,7 @@ def _model_structure(config):
             shape=(config.n_subjects, config.n_modes, 1),
             learn=config.learn_covariances,
             initializer=osld_initializers.RandomWeightInitializer(
-                tfp.math.softplus_inverse(config.initial_dev.get("covs_beta", 10.0)),
+                tfp.math.softplus_inverse(config.initial_dev.get("covs_beta", 5.0)),
                 0.1,
             ),
             name="covs_dev_mag_inf_beta_input",
@@ -788,7 +788,7 @@ def _model_structure(config):
             "softplus", name="covs_dev_mag_inf_beta"
         )
         covs_dev_mag_layer = SampleGammaDistributionLayer(
-            config.covariances_epsilon, name="covs_dev_mag"
+            config.covariances_epsilon, config.do_kl_annealing, name="covs_dev_mag"
         )
         covs_dev_layer = layers.Multiply(name="covs_dev")
 

--- a/osl_dynamics/models/sedynemo.py
+++ b/osl_dynamics/models/sedynemo.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 
 import numpy as np
 import tensorflow as tf
+import tensorflow_probability as tfp
 from tensorflow.keras import layers, initializers
 
 import osl_dynamics.data.tf as dtf
@@ -15,6 +16,7 @@ from osl_dynamics.models.inf_mod_base import (
     VariationalInferenceModelConfig,
     VariationalInferenceModelBase,
 )
+import osl_dynamics.inference.initializers as osld_initializers
 from osl_dynamics.inference.layers import (
     InferenceRNNLayer,
     LogLikelihoodLossLayer,
@@ -164,6 +166,8 @@ class Config(BaseModelConfig, VariationalInferenceModelConfig):
     dev_regularizer_factor : float
         Regularizer factor for the MLP for deviations.
         This will be scaled by the amount of data.
+    initial_dev : dict
+        Initialisation for dev posterior parameters.
     """
 
     model_name: str = "SE-DyNeMo"
@@ -207,6 +211,7 @@ class Config(BaseModelConfig, VariationalInferenceModelConfig):
     dev_dropout: float = 0.0
     dev_regularizer: str = None
     dev_regularizer_factor: float = 0.0
+    initial_dev: dict = None
 
     def __post_init__(self):
         self.validate_rnn_parameters()
@@ -233,6 +238,9 @@ class Config(BaseModelConfig, VariationalInferenceModelConfig):
                 self.covariances_epsilon = 1e-6
             else:
                 self.covariances_epsilon = 0.0
+
+        if self.initial_dev is None:
+            self.initial_dev = dict()
 
     def validate_subject_embedding_parameters(self):
         if (
@@ -379,6 +387,22 @@ class Model(VariationalInferenceModelBase):
                 self.config.covariances_epsilon,
                 layer_name="group_covs",
             )
+
+    def set_dev_parameters_initializer(self, training_dataset):
+        """Set the deviance parameters initializer based on training data.
+
+        Parameters
+        ----------
+        training_dataset : osl_dynamics.data.Data
+            The training dataset.
+        """
+        obs_mod.set_dev_parameters_initializer(
+            self.model,
+            training_dataset,
+            self.config.learn_means,
+            self.config.learn_covariances,
+        )
+        self.reset()
 
     def set_group_means(self, group_means, update_initializer=True):
         """Set the group means of each mode.
@@ -621,7 +645,7 @@ def _model_structure(config):
             name="means_concat_embeddings",
         )
 
-        means_dev_map_input_layer = MultiLayerPerceptronLayer(
+        means_dev_decoder_layer = MultiLayerPerceptronLayer(
             config.dev_n_layers,
             config.dev_n_units,
             config.dev_normalization,
@@ -629,7 +653,7 @@ def _model_structure(config):
             config.dev_dropout,
             config.dev_regularizer,
             config.dev_regularizer_factor,
-            name="means_dev_map_input",
+            name="means_dev_decoder",
         )
         means_dev_map_layer = layers.Dense(
             config.n_channels,
@@ -643,7 +667,10 @@ def _model_structure(config):
         means_dev_mag_inf_alpha_input_layer = LearnableTensorLayer(
             shape=(config.n_subjects, config.n_modes, 1),
             learn=config.learn_means,
-            initializer=initializers.TruncatedNormal(mean=0, stddev=0.02),
+            initializer=osld_initializers.RandomWeightInitializer(
+                tfp.math.softplus_inverse(config.initial_dev.get("means_alpha", 0.0)),
+                0.1,
+            ),
             name="means_dev_mag_inf_alpha_input",
         )
         means_dev_mag_inf_alpha_layer = layers.Activation(
@@ -652,7 +679,10 @@ def _model_structure(config):
         means_dev_mag_inf_beta_input_layer = LearnableTensorLayer(
             shape=(config.n_subjects, config.n_modes, 1),
             learn=config.learn_means,
-            initializer=initializers.TruncatedNormal(mean=10, stddev=0.02),
+            initializer=osld_initializers.RandomWeightInitializer(
+                tfp.math.softplus_inverse(config.initial_dev.get("means_beta", 10.0)),
+                0.1,
+            ),
             name="means_dev_mag_inf_beta_input",
         )
         means_dev_mag_inf_beta_layer = layers.Activation(
@@ -673,11 +703,11 @@ def _model_structure(config):
         )
 
         # Get the mean deviation maps (no global magnitude information)
-        means_dev_map_input = means_dev_map_input_layer(
+        means_dev_decoder = means_dev_decoder_layer(
             means_concat_embeddings,
             static_loss_scaling_factor=static_loss_scaling_factor,
         )
-        means_dev_map = means_dev_map_layer(means_dev_map_input)
+        means_dev_map = means_dev_map_layer(means_dev_decoder)
         norm_means_dev_map = norm_means_dev_map_layer(means_dev_map)
 
         # Get the deviation magnitudes (scale deviation maps globally)
@@ -716,7 +746,7 @@ def _model_structure(config):
             name="covs_concat_embeddings",
         )
 
-        covs_dev_map_input_layer = MultiLayerPerceptronLayer(
+        covs_dev_decoder_layer = MultiLayerPerceptronLayer(
             config.dev_n_layers,
             config.dev_n_units,
             config.dev_normalization,
@@ -724,7 +754,7 @@ def _model_structure(config):
             config.dev_dropout,
             config.dev_regularizer,
             config.dev_regularizer_factor,
-            name="covs_dev_map_input",
+            name="covs_dev_decoder",
         )
         covs_dev_map_layer = layers.Dense(
             config.n_channels * (config.n_channels + 1) // 2, name="covs_dev_map"
@@ -736,7 +766,10 @@ def _model_structure(config):
         covs_dev_mag_inf_alpha_input_layer = LearnableTensorLayer(
             shape=(config.n_subjects, config.n_modes, 1),
             learn=config.learn_covariances,
-            initializer=initializers.TruncatedNormal(mean=20, stddev=10),
+            initializer=osld_initializers.RandomWeightInitializer(
+                tfp.math.softplus_inverse(config.initial_dev.get("covs_alpha", 0.0)),
+                0.1,
+            ),
             name="covs_dev_mag_inf_alpha_input",
         )
         covs_dev_mag_inf_alpha_layer = layers.Activation(
@@ -745,7 +778,10 @@ def _model_structure(config):
         covs_dev_mag_inf_beta_input_layer = LearnableTensorLayer(
             shape=(config.n_subjects, config.n_modes, 1),
             learn=config.learn_covariances,
-            initializer=initializers.TruncatedNormal(mean=100, stddev=20),
+            initializer=osld_initializers.RandomWeightInitializer(
+                tfp.math.softplus_inverse(config.initial_dev.get("covs_beta", 10.0)),
+                0.1,
+            ),
             name="covs_dev_mag_inf_beta_input",
         )
         covs_dev_mag_inf_beta_layer = layers.Activation(
@@ -767,11 +803,11 @@ def _model_structure(config):
         )
 
         # Get the covariance deviation maps (no global magnitude information)
-        covs_dev_map_input = covs_dev_map_input_layer(
+        covs_dev_decoder = covs_dev_decoder_layer(
             covs_concat_embeddings,
             static_loss_scaling_factor=static_loss_scaling_factor,
         )
-        covs_dev_map = covs_dev_map_layer(covs_dev_map_input)
+        covs_dev_map = covs_dev_map_layer(covs_dev_decoder)
         norm_covs_dev_map = norm_covs_dev_map_layer(covs_dev_map)
 
         # Get the deviation magnitudes (scale deviation maps globally)
@@ -864,16 +900,6 @@ def _model_structure(config):
     # For the observation model (static KL loss)
     if config.learn_means:
         # Layer definitions
-        means_dev_mag_mod_beta_input_layer = MultiLayerPerceptronLayer(
-            config.dev_n_layers,
-            config.dev_n_units,
-            config.dev_normalization,
-            config.dev_activation,
-            config.dev_dropout,
-            config.dev_regularizer,
-            config.dev_regularizer_factor,
-            name="means_dev_mag_mod_beta_input",
-        )
         means_dev_mag_mod_beta_layer = layers.Dense(
             1,
             activation="softplus",
@@ -885,13 +911,7 @@ def _model_structure(config):
         )
 
         # Data flow
-        means_dev_mag_mod_beta_input = means_dev_mag_mod_beta_input_layer(
-            means_concat_embeddings,
-            static_loss_scaling_factor=static_loss_scaling_factor,
-        )
-        means_dev_mag_mod_beta = means_dev_mag_mod_beta_layer(
-            means_dev_mag_mod_beta_input
-        )
+        means_dev_mag_mod_beta = means_dev_mag_mod_beta_layer(means_dev_decoder)
         means_dev_mag_kl_loss = means_dev_mag_kl_loss_layer(
             [
                 data,
@@ -910,16 +930,6 @@ def _model_structure(config):
 
     if config.learn_covariances:
         # Layer definitions
-        covs_dev_mag_mod_beta_input_layer = MultiLayerPerceptronLayer(
-            config.dev_n_layers,
-            config.dev_n_units,
-            config.dev_normalization,
-            config.dev_activation,
-            config.dev_dropout,
-            config.dev_regularizer,
-            config.dev_regularizer_factor,
-            name="covs_dev_mag_mod_beta_input",
-        )
         covs_dev_mag_mod_beta_layer = layers.Dense(
             1,
             activation="softplus",
@@ -931,13 +941,7 @@ def _model_structure(config):
         )
 
         # Data flow
-        covs_dev_mag_mod_beta_input = covs_dev_mag_mod_beta_input_layer(
-            covs_concat_embeddings,
-            static_loss_scaling_factor=static_loss_scaling_factor,
-        )
-        covs_dev_mag_mod_beta = covs_dev_mag_mod_beta_layer(
-            covs_dev_mag_mod_beta_input,
-        )
+        covs_dev_mag_mod_beta = covs_dev_mag_mod_beta_layer(covs_dev_decoder)
         covs_dev_mag_kl_loss = covs_dev_mag_kl_loss_layer(
             [
                 data,

--- a/osl_dynamics/models/sehmm.py
+++ b/osl_dynamics/models/sehmm.py
@@ -659,7 +659,7 @@ def _model_structure(config):
             name="means_dev_map",
         )
         norm_means_dev_map_layer = layers.LayerNormalization(
-            axis=-1, name="norm_means_dev_map"
+            axis=-1, scale=False, name="norm_means_dev_map"
         )
 
         means_dev_mag_inf_alpha_input_layer = LearnableTensorLayer(
@@ -678,7 +678,7 @@ def _model_structure(config):
             shape=(config.n_subjects, config.n_states, 1),
             learn=config.learn_means,
             initializer=osld_initializers.RandomWeightInitializer(
-                tfp.math.softplus_inverse(config.initial_dev.get("means_beta", 10.0)),
+                tfp.math.softplus_inverse(config.initial_dev.get("means_beta", 5.0)),
                 0.1,
             ),
             name="means_dev_mag_inf_beta_input",
@@ -687,7 +687,7 @@ def _model_structure(config):
             "softplus", name="means_dev_mag_inf_beta"
         )
         means_dev_mag_layer = SampleGammaDistributionLayer(
-            config.covariances_epsilon, name="means_dev_mag"
+            config.covariances_epsilon, config.do_kl_annealing, name="means_dev_mag"
         )
 
         means_dev_layer = layers.Multiply(name="means_dev")
@@ -759,7 +759,7 @@ def _model_structure(config):
             name="covs_dev_map",
         )
         norm_covs_dev_map_layer = layers.LayerNormalization(
-            axis=-1, name="norm_covs_dev_map"
+            axis=-1, scale=False, name="norm_covs_dev_map"
         )
 
         covs_dev_mag_inf_alpha_input_layer = LearnableTensorLayer(
@@ -778,7 +778,7 @@ def _model_structure(config):
             shape=(config.n_subjects, config.n_states, 1),
             learn=config.learn_covariances,
             initializer=osld_initializers.RandomWeightInitializer(
-                tfp.math.softplus_inverse(config.initial_dev.get("covs_beta", 10.0)),
+                tfp.math.softplus_inverse(config.initial_dev.get("covs_beta", 5.0)),
                 0.1,
             ),
             name="covs_dev_mag_inf_beta_input",
@@ -787,7 +787,7 @@ def _model_structure(config):
             "softplus", name="covs_dev_mag_inf_beta"
         )
         covs_dev_mag_layer = SampleGammaDistributionLayer(
-            config.covariances_epsilon, name="covs_dev_mag"
+            config.covariances_epsilon, config.do_kl_annealing, name="covs_dev_mag"
         )
         covs_dev_layer = layers.Multiply(name="covs_dev")
 

--- a/osl_dynamics/models/sehmm.py
+++ b/osl_dynamics/models/sehmm.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 
 import numpy as np
 import tensorflow as tf
+import tensorflow_probability as tfp
 from tensorflow.keras import layers, initializers
 
 from osl_dynamics.inference.layers import (
@@ -30,6 +31,7 @@ from osl_dynamics.inference.layers import (
 from osl_dynamics.models import obs_mod
 from osl_dynamics.models.mod_base import BaseModelConfig
 from osl_dynamics.inference import callbacks
+import osl_dynamics.inference.initializers as osld_initializers
 from osl_dynamics.models.inf_mod_base import (
     MarkovStateInferenceModelConfig,
     MarkovStateInferenceModelBase,
@@ -92,6 +94,8 @@ class Config(BaseModelConfig, MarkovStateInferenceModelConfig):
     dev_regularizer_factor : float
         Regularizer factor for the MLP for deviations.
         This will be scaled by the amount of data.
+    initial_dev : dict
+        Initialisation for dev posterior parameters.
 
     initial_trans_prob : np.ndarray
         Initialisation for transition probability matrix.
@@ -160,6 +164,7 @@ class Config(BaseModelConfig, MarkovStateInferenceModelConfig):
     dev_dropout: float = 0.0
     dev_regularizer: str = None
     dev_regularizer_factor: float = 0.0
+    initial_dev: dict = None
 
     # KL annealing parameters
     do_kl_annealing: bool = False
@@ -184,6 +189,9 @@ class Config(BaseModelConfig, MarkovStateInferenceModelConfig):
                 self.covariances_epsilon = 1e-6
             else:
                 self.covariances_epsilon = 0.0
+
+        if self.initial_dev is None:
+            self.initial_dev = dict()
 
     def validate_subject_embedding_parameters(self):
         if (
@@ -524,6 +532,22 @@ class Model(MarkovStateInferenceModelBase):
                 layer_name="group_covs",
             )
 
+    def set_dev_parameters_initializer(self, training_dataset):
+        """Set the deviance parameters initializer based on training data.
+
+        Parameters
+        ----------
+        training_dataset : osl_dynamics.data.Data
+            The training dataset.
+        """
+        obs_mod.set_dev_parameters_initializer(
+            self.model,
+            training_dataset,
+            self.config.learn_means,
+            self.config.learn_covariances,
+        )
+        self.reset()
+
     def get_n_params_generative_model(self):
         """Get the number of trainable parameters in the generative model.
 
@@ -620,8 +644,7 @@ def _model_structure(config):
         means_concat_embeddings_layer = ConcatEmbeddingsLayer(
             name="means_concat_embeddings",
         )
-
-        means_dev_map_input_layer = MultiLayerPerceptronLayer(
+        means_dev_decoder_layer = MultiLayerPerceptronLayer(
             config.dev_n_layers,
             config.dev_n_units,
             config.dev_normalization,
@@ -629,7 +652,7 @@ def _model_structure(config):
             config.dev_dropout,
             config.dev_regularizer,
             config.dev_regularizer_factor,
-            name="means_dev_map_input",
+            name="means_dev_decoder",
         )
         means_dev_map_layer = layers.Dense(
             config.n_channels,
@@ -642,7 +665,10 @@ def _model_structure(config):
         means_dev_mag_inf_alpha_input_layer = LearnableTensorLayer(
             shape=(config.n_subjects, config.n_states, 1),
             learn=config.learn_means,
-            initializer=initializers.TruncatedNormal(mean=20, stddev=10),
+            initializer=osld_initializers.RandomWeightInitializer(
+                tfp.math.softplus_inverse(config.initial_dev.get("means_alpha", 0.0)),
+                0.1,
+            ),
             name="means_dev_mag_inf_alpha_input",
         )
         means_dev_mag_inf_alpha_layer = layers.Activation(
@@ -651,7 +677,10 @@ def _model_structure(config):
         means_dev_mag_inf_beta_input_layer = LearnableTensorLayer(
             shape=(config.n_subjects, config.n_states, 1),
             learn=config.learn_means,
-            initializer=initializers.TruncatedNormal(mean=100, stddev=20),
+            initializer=osld_initializers.RandomWeightInitializer(
+                tfp.math.softplus_inverse(config.initial_dev.get("means_beta", 10.0)),
+                0.1,
+            ),
             name="means_dev_mag_inf_beta_input",
         )
         means_dev_mag_inf_beta_layer = layers.Activation(
@@ -672,11 +701,11 @@ def _model_structure(config):
         )
 
         # Get the mean deviation maps (no global magnitude information)
-        means_dev_map_input = means_dev_map_input_layer(
+        means_dev_decoder = means_dev_decoder_layer(
             means_concat_embeddings,
             static_loss_scaling_factor=static_loss_scaling_factor,
         )
-        means_dev_map = means_dev_map_layer(means_dev_map_input)
+        means_dev_map = means_dev_map_layer(means_dev_decoder)
         norm_means_dev_map = norm_means_dev_map_layer(means_dev_map)
 
         # Get the deviation magnitudes (scale deviation maps globally)
@@ -715,7 +744,7 @@ def _model_structure(config):
             name="covs_concat_embeddings",
         )
 
-        covs_dev_map_input_layer = MultiLayerPerceptronLayer(
+        covs_dev_decoder_layer = MultiLayerPerceptronLayer(
             config.dev_n_layers,
             config.dev_n_units,
             config.dev_normalization,
@@ -723,7 +752,7 @@ def _model_structure(config):
             config.dev_dropout,
             config.dev_regularizer,
             config.dev_regularizer_factor,
-            name="covs_dev_map_input",
+            name="covs_dev_decoder",
         )
         covs_dev_map_layer = layers.Dense(
             config.n_channels * (config.n_channels + 1) // 2,
@@ -736,7 +765,10 @@ def _model_structure(config):
         covs_dev_mag_inf_alpha_input_layer = LearnableTensorLayer(
             shape=(config.n_subjects, config.n_states, 1),
             learn=config.learn_covariances,
-            initializer=initializers.TruncatedNormal(mean=20, stddev=10),
+            initializer=osld_initializers.RandomWeightInitializer(
+                tfp.math.softplus_inverse(config.initial_dev.get("covs_alpha", 0.0)),
+                0.1,
+            ),
             name="covs_dev_mag_inf_alpha_input",
         )
         covs_dev_mag_inf_alpha_layer = layers.Activation(
@@ -745,7 +777,10 @@ def _model_structure(config):
         covs_dev_mag_inf_beta_input_layer = LearnableTensorLayer(
             shape=(config.n_subjects, config.n_states, 1),
             learn=config.learn_covariances,
-            initializer=initializers.TruncatedNormal(mean=100, stddev=20),
+            initializer=osld_initializers.RandomWeightInitializer(
+                tfp.math.softplus_inverse(config.initial_dev.get("covs_beta", 10.0)),
+                0.1,
+            ),
             name="covs_dev_mag_inf_beta_input",
         )
         covs_dev_mag_inf_beta_layer = layers.Activation(
@@ -767,11 +802,11 @@ def _model_structure(config):
         )
 
         # Get the covariance deviation maps (no global magnitude information)
-        covs_dev_map_input = covs_dev_map_input_layer(
+        covs_dev_decoder = covs_dev_decoder_layer(
             covs_concat_embeddings,
             static_loss_scaling_factor=static_loss_scaling_factor,
         )
-        covs_dev_map = covs_dev_map_layer(covs_dev_map_input)
+        covs_dev_map = covs_dev_map_layer(covs_dev_decoder)
         norm_covs_dev_map = norm_covs_dev_map_layer(covs_dev_map)
 
         # Get the deviation magnitudes (scale deviation maps globally)
@@ -845,16 +880,6 @@ def _model_structure(config):
     # For the observation model (static KL loss)
     if config.learn_means:
         # Layer definitions
-        means_dev_mag_mod_beta_input_layer = MultiLayerPerceptronLayer(
-            config.dev_n_layers,
-            config.dev_n_units,
-            config.dev_normalization,
-            config.dev_activation,
-            config.dev_dropout,
-            config.dev_regularizer,
-            config.dev_regularizer_factor,
-            name="means_dev_mag_mod_beta_input",
-        )
         means_dev_mag_mod_beta_layer = layers.Dense(
             1,
             activation="softplus",
@@ -866,13 +891,7 @@ def _model_structure(config):
         )
 
         # Data flow
-        means_dev_mag_mod_beta_input = means_dev_mag_mod_beta_input_layer(
-            means_concat_embeddings,
-            static_loss_scaling_factor=static_loss_scaling_factor,
-        )
-        means_dev_mag_mod_beta = means_dev_mag_mod_beta_layer(
-            means_dev_mag_mod_beta_input
-        )
+        means_dev_mag_mod_beta = means_dev_mag_mod_beta_layer(means_dev_decoder)
         means_dev_mag_kl_loss = means_dev_mag_kl_loss_layer(
             [
                 data,
@@ -891,16 +910,6 @@ def _model_structure(config):
 
     if config.learn_covariances:
         # Layer definitions
-        covs_dev_mag_mod_beta_input_layer = MultiLayerPerceptronLayer(
-            config.dev_n_layers,
-            config.dev_n_units,
-            config.dev_normalization,
-            config.dev_activation,
-            config.dev_dropout,
-            config.dev_regularizer,
-            config.dev_regularizer_factor,
-            name="covs_dev_mag_mod_beta_input",
-        )
         covs_dev_mag_mod_beta_layer = layers.Dense(
             1,
             activation="softplus",
@@ -912,12 +921,8 @@ def _model_structure(config):
         )
 
         # Data flow
-        covs_dev_mag_mod_beta_input = covs_dev_mag_mod_beta_input_layer(
-            covs_concat_embeddings,
-            static_loss_scaling_factor=static_loss_scaling_factor,
-        )
         covs_dev_mag_mod_beta = covs_dev_mag_mod_beta_layer(
-            covs_dev_mag_mod_beta_input,
+            covs_dev_decoder,
         )
         covs_dev_mag_kl_loss = covs_dev_mag_kl_loss_layer(
             [


### PR DESCRIPTION
This PR consists of mainly the following changes for better convergence of SE-HMM (and potentially SE-DyNeMo):

- Single decoder for both deviation magnitude and deviation map. This reduces the number of parameters in the model, providing better training stability, while maintaining the expressiveness of the model.
- Method to initialise the parameters of the deviation posterior with training data. This greatly improves the convergence of the model by initialising the model in a "good" spot.
- It is now possible to anneal the sampling process of deviation posterior during reparameterisation. This serves as a exploration vs exploitation process. In the beginning of the process, only the mean is sampled and the gradient will intend to push the mean deviations to the correct spot. This is the exploration phase. As training progresses, we gradually take into account the variance of the deviation posterior and fine tune the posterior parameters. This is the exploitation phase. It is found that it helps the model covergence.
- Finally, the config API wrapper is updated to accommodate the above changes.