### PR TITLE
Refactored dual estimation for HMM and wrapper to train SE-HMM.

### DIFF
--- a/osl_dynamics/config_api/wrappers.py
+++ b/osl_dynamics/config_api/wrappers.py
@@ -769,15 +769,15 @@ def dual_estimation(data, output_dir, n_jobs=1):
     os.makedirs(dual_estimates_dir, exist_ok=True)
 
     #  Load model
-    from osl_dynamics.models import load
+    from osl_dynamics import models
 
-    model = load(model_dir)
+    model = models.load(model_dir)
 
     # Load the inferred state probabilities
     alpha = load(f"{inf_params_dir}/alp.pkl")
 
     # Dual estimation
-    means, covs = model.dual_estimation(data, n_jobs=n_jobs)
+    means, covs = model.dual_estimation(data, alpha=alpha, n_jobs=n_jobs)
 
     # Save
     save(f"{dual_estimates_dir}/means.npy", means)

--- a/osl_dynamics/config_api/wrappers.py
+++ b/osl_dynamics/config_api/wrappers.py
@@ -320,6 +320,7 @@ def train_sehmm(
     init_kwargs=None,
     fit_kwargs=None,
     save_inf_params=True,
+    n_jobs=1,
 ):
     """ Train a `Subject embedding Hidden Markov Model <https://osl-dynamics.\
     readthedocs.io/en/latest/autoapi/osl_dynamics/models/sehmm/index.html>`_.
@@ -331,10 +332,11 @@ def train_sehmm(
         :code:`Model.random_state_time_course_initialization`.
     3. Build an :code:`sehmm.Model` object.
     4. Initialize the parameters of the SE-HMM model using pretrained HMM.
-    2. Initialize the parameters of the SE-HMM model using
+    5. Initialize the subject embeddings with PCA'ed dual estimated covariances.
+    6. Initialize the parameters of the SE-HMM model using
         :code:`Model.random_state_time_course_initialization`.
-    3. Perform full training.
-    4. Save the inferred parameters (state probabilities, means,
+    7. Perform full training.
+    8. Save the inferred parameters (state probabilities, means,
         covariances and subject embeddings) if :code:`save_inf_params=True`.
     
     This function will create two directories:
@@ -393,11 +395,14 @@ def train_sehmm(
         Keyword arguments to pass to the :code:`Model.fit`. No defaults.
     save_inf_params : bool, optional
         Should we save the inferred parameters?
+    n_jobs : int, optional
+        Number of jobs to run in parallel.
     """
     if data is None:
         raise ValueError("data must be passed.")
 
     from osl_dynamics.models import hmm, sehmm
+    from sklearn.decomposition import PCA
 
     init_kwargs = {} if init_kwargs is None else init_kwargs
     fit_kwargs = {} if fit_kwargs is None else fit_kwargs
@@ -474,11 +479,18 @@ def train_sehmm(
     # Set deviation initializer
     model.set_dev_parameters_initializer(data)
 
+    # Initialise subject embeddings
+    _, init_dual_covs = init_model.dual_estimation(data, n_jobs=n_jobs)
+    pca = PCA(n_components=config_kwargs["subject_embeddings_dim"])
+    model.set_subject_embeddings_initializer(pca.fit_transform(init_dual_covs))
+
+    # Initialise SE-HMM with subject embeddings fixed
     _logger.info(f"Using init_kwargs: {init_kwargs}")
-    init_history = model.random_state_time_course_initialization(
-        data,
-        **init_kwargs,
-    )
+    with model.set_trainable("subject_embeddings", False):
+        init_history = model.random_state_time_course_initialization(
+            data,
+            **init_kwargs,
+        )
 
     # Training
     history = model.fit(data, **fit_kwargs)

--- a/osl_dynamics/models/dynemo.py
+++ b/osl_dynamics/models/dynemo.py
@@ -535,7 +535,7 @@ class Model(VariationalInferenceModelBase):
         n_epochs=None,
         learning_rate=None,
         store_dir="tmp",
-        alpha=None,
+        **kwargs,
     ):
         """Dual estimation to get the subject-specific observation model
         parameters.
@@ -556,8 +556,6 @@ class Model(VariationalInferenceModelBase):
             to create the model.
         store_dir : str, optional
             Directory to temporarily store the model in.
-        alpha : np.ndarray, optional
-            For consistency with API, ignored.
 
         Returns
         -------

--- a/osl_dynamics/models/dynemo.py
+++ b/osl_dynamics/models/dynemo.py
@@ -530,7 +530,12 @@ class Model(VariationalInferenceModelBase):
         return alpha, np.array(means), np.array(covariances)
 
     def dual_estimation(
-        self, training_data, n_epochs=None, learning_rate=None, store_dir="tmp"
+        self,
+        training_data,
+        n_epochs=None,
+        learning_rate=None,
+        store_dir="tmp",
+        alpha=None,
     ):
         """Dual estimation to get the subject-specific observation model
         parameters.
@@ -551,6 +556,8 @@ class Model(VariationalInferenceModelBase):
             to create the model.
         store_dir : str, optional
             Directory to temporarily store the model in.
+        alpha : np.ndarray, optional
+            For consistency with API, ignored.
 
         Returns
         -------

--- a/osl_dynamics/models/hmm.py
+++ b/osl_dynamics/models/hmm.py
@@ -1404,7 +1404,7 @@ class Model(ModelBase):
 
         # Helper function for dual estimation for a single subject
         def _single_dual_estimation(a, x):
-            a /= np.sum(a, axis=1, keepdims=True)
+            a /= np.sum(a, axis=0, keepdims=True)
             if self.config.learn_means:
                 subject_means = np.empty((n_states, n_channels))
                 for state in range(n_states):

--- a/osl_dynamics/models/obs_mod.py
+++ b/osl_dynamics/models/obs_mod.py
@@ -153,6 +153,22 @@ def set_dev_parameters_initializer(
         covs_beta_layer.tensor_initializer = RandomWeightInitializer(covs_beta, 0.1)
 
 
+def set_subject_embeddings_initializer(model, subject_embeddings):
+    """Set the subject embeddings initializer.
+
+    Parameters
+    ----------
+    model : osl_dynamics.models.*.Model.model
+        The model. * must be :code:`sehmm` or :code:`sedynemo`.
+    subject_embeddings : np.ndarray
+        The subject embeddings. Shape is (n_subjects, subject_embeddings_dim).
+    """
+    subject_embeddings_layer = model.get_layer("subject_embeddings")
+    subject_embeddings_layer.embeddings_initializer = WeightInitializer(
+        subject_embeddings
+    )
+
+
 def set_means_regularizer(model, training_dataset, layer_name="means"):
     """Set the means regularizer based on training data.
 

--- a/osl_dynamics/models/sedynemo.py
+++ b/osl_dynamics/models/sedynemo.py
@@ -404,6 +404,20 @@ class Model(VariationalInferenceModelBase):
         )
         self.reset()
 
+    def set_subject_embeddings_initializer(self, subject_embeddings):
+        """Set the subject embeddings initializer.
+
+        Parameters
+        ----------
+        subject_embeddings : np.ndarray
+            Subject embeddings. Shape is (n_subjects, subject_embeddings_dim).
+        """
+        obs_mod.set_subject_embeddings_initializer(
+            self.model,
+            subject_embeddings,
+        )
+        self.reset()
+
     def set_group_means(self, group_means, update_initializer=True):
         """Set the group means of each mode.
 

--- a/osl_dynamics/models/sehmm.py
+++ b/osl_dynamics/models/sehmm.py
@@ -548,6 +548,20 @@ class Model(MarkovStateInferenceModelBase):
         )
         self.reset()
 
+    def set_subject_embeddings_initializer(self, subject_embeddings):
+        """Set the subject embeddings initializer.
+
+        Parameters
+        ----------
+        subject_embeddings : np.ndarray
+            Subject embeddings. Shape is (n_subjects, subject_embeddings_dim).
+        """
+        obs_mod.set_subject_embeddings_initializer(
+            self.model,
+            subject_embeddings,
+        )
+        self.reset()
+
     def get_n_params_generative_model(self):
         """Get the number of trainable parameters in the generative model.
 


### PR DESCRIPTION
Changes:

- Introduced for loops that loop through states in dual estimation for HMM. This significantly reduces memory consumption while maintaining good speed.
- Improved initialisation of SE-HMM. Now subject embeddings are initialised by PCA'ed dual estimated covariances from a pre-trained HMM.