### PR TITLE
Multiple GPU training and prepare for newer TF versions

### DIFF
--- a/osl_dynamics/data/base.py
+++ b/osl_dynamics/data/base.py
@@ -965,6 +965,7 @@ class Data:
         validation_split=None,
         concatenate=True,
         step_size=None,
+        drop_last_batch=False,
     ):
         """Create a Tensorflow Dataset for training or evaluation.
 
@@ -984,6 +985,8 @@ class Data:
         step_size : int, optional
             Number of samples to slide the sequence across the dataset.
             Default is no overlap.
+        drop_last_batch : bool, optional
+            Should we drop the last batch if it is smaller than the batch size?
 
         Returns
         -------
@@ -1030,14 +1033,18 @@ class Data:
                 full_dataset = full_dataset.shuffle(self.buffer_size)
 
                 # Group into mini-batches
-                full_dataset = full_dataset.batch(self.batch_size)
+                full_dataset = full_dataset.batch(
+                    self.batch_size, drop_remainder=drop_last_batch
+                )
 
                 # Shuffle mini-batches
                 full_dataset = full_dataset.shuffle(self.buffer_size)
 
             else:
                 # Group into mini-batches
-                full_dataset = full_dataset.batch(self.batch_size)
+                full_dataset = full_dataset.batch(
+                    self.batch_size, drop_remainder=drop_last_batch
+                )
 
             if validation_split is None:
                 # Return the full dataset
@@ -1070,7 +1077,7 @@ class Data:
                     ds = ds.shuffle(self.buffer_size)
 
                 # Group into batches
-                ds = ds.batch(self.batch_size)
+                ds = ds.batch(self.batch_size, drop_remainder=drop_last_batch)
 
                 if shuffle:
                     # Shuffle batches
@@ -1116,6 +1123,7 @@ class Data:
         validation_split=None,
         concatenate=True,
         step_size=None,
+        drop_last_batch=False,
     ):
         """Create a TFRecord Dataset for training or evaluation.
 
@@ -1134,6 +1142,8 @@ class Data:
         step_size : int, optional
             Number of samples to slide the sequence across the dataset.
             Default is no overlap.
+        drop_last_batch : bool, optional
+            Should we drop the last batch if it is smaller than the batch size?
 
         Returns
         -------
@@ -1237,7 +1247,9 @@ class Data:
                 full_dataset = full_dataset.shuffle(self.buffer_size)
 
                 # Group into batches
-                full_dataset = full_dataset.batch(self.batch_size)
+                full_dataset = full_dataset.batch(
+                    self.batch_size, drop_remainder=drop_last_batch
+                )
 
                 # Shuffle batches
                 full_dataset = full_dataset.shuffle(self.buffer_size)
@@ -1252,7 +1264,9 @@ class Data:
                 full_dataset = full_dataset.map(_parse_example)
 
                 # Group into batches
-                full_dataset = full_dataset.batch(self.batch_size)
+                full_dataset = full_dataset.batch(
+                    self.batch_size, drop_remainder=drop_last_batch
+                )
 
             if validation_split is None:
                 # Return the dataset
@@ -1289,7 +1303,7 @@ class Data:
                     ds = ds.shuffle(self.buffer_size)
 
                 # Group into batches
-                ds = ds.batch(self.batch_size)
+                ds = ds.batch(self.batch_size, drop_remainder=drop_last_batch)
 
                 if shuffle:
                     # Shuffle batches

--- a/osl_dynamics/data/base.py
+++ b/osl_dynamics/data/base.py
@@ -1199,6 +1199,10 @@ class Data:
         # Helper function for parsing training examples
         def _parse_example(example):
             feature_names = ["data", "array_id"]
+            tensor_shapes = {
+                "data": [self.sequence_length, self.n_channels],
+                "array_id": [self.sequence_length],
+            }
             feature_description = {
                 name: tf.io.FixedLenFeature([], tf.string) for name in feature_names
             }
@@ -1207,7 +1211,9 @@ class Data:
                 feature_description,
             )
             return {
-                name: tf.io.parse_tensor(tensor, tf.float32)
+                name: tf.ensure_shape(
+                    tf.io.parse_tensor(tensor, tf.float32), tensor_shapes[name]
+                )
                 for name, tensor in parsed_example.items()
             }
 

--- a/osl_dynamics/inference/layers.py
+++ b/osl_dynamics/inference/layers.py
@@ -1796,6 +1796,8 @@ class HiddenMarkovStateInferenceLayer(layers.Layer):
                 # This is accounted for when updating the variable
                 # in inference.optimizers.ExponentialMovingAverageOptimizer
                 phi_interim = self._trans_prob_update(log_gamma, log_xi)
+
+                phi_interim = tf.cast(phi_interim, tf.float32)
                 return None, [phi_interim]
 
             return (tf.exp(log_gamma), tf.exp(log_xi)), grad

--- a/osl_dynamics/models/__init__.py
+++ b/osl_dynamics/models/__init__.py
@@ -27,13 +27,15 @@ models = {
 }
 
 
-def load(dirname):
+def load(dirname, single_gpu=True):
     """Load model from dirname.
 
     Parameters
     ----------
     dirname : str
         Path to directory where the config.yml and weights are stored.
+    single_gpu : bool, optional
+        Should we compile the model on a single GPU?
 
     Returns
     -------
@@ -57,4 +59,4 @@ def load(dirname):
             + f"Options are {', '.join(models.keys())}"
         )
 
-    return model_type.load(dirname)
+    return model_type.load(dirname, single_gpu=single_gpu)

--- a/osl_dynamics/models/inf_mod_base.py
+++ b/osl_dynamics/models/inf_mod_base.py
@@ -16,7 +16,7 @@ import osl_dynamics.data.tf as dtf
 from osl_dynamics.simulation import HMM
 from osl_dynamics.inference import callbacks, optimizers
 from osl_dynamics.inference.initializers import WeightInitializer
-from osl_dynamics.models.mod_base import ModelBase, single_gpu_model
+from osl_dynamics.models.mod_base import ModelBase
 from osl_dynamics.utils.misc import replace_argument
 
 _logger = logging.getLogger("osl-dynamics")
@@ -445,7 +445,13 @@ class VariationalInferenceModelBase(ModelBase):
             Mode mixing logits for FC.
             Only returned if :code:`self.config.multiple_dynamics=True`.
         """
-        self = single_gpu_model(self)
+        if self.is_multi_gpu:
+            raise ValueError(
+                "MirroredStrategy is not supported for this method. "
+                + "Please load a new model with "
+                + "osl_dynamics.models.load(..., single_gpu=True)."
+            )
+
         if self.config.multiple_dynamics:
             return self.get_mode_logits(
                 dataset,
@@ -514,7 +520,13 @@ class VariationalInferenceModelBase(ModelBase):
             Mode mixing logits for FC with shape (n_subjects, n_samples,
             n_modes) or (n_samples, n_modes).
         """
-        self = single_gpu_model(self)
+        if self.is_multi_gpu:
+            raise ValueError(
+                "MirroredStrategy is not supported for this method. "
+                + "Please load a new model with "
+                + "osl_dynamics.models.load(..., single_gpu=True)."
+            )
+
         if not self.config.multiple_dynamics:
             raise ValueError("Please use get_theta for a single time scale model.")
 
@@ -585,7 +597,13 @@ class VariationalInferenceModelBase(ModelBase):
             Mode mixing coefficients with shape (n_subjects, n_samples,
             n_modes) or (n_samples, n_modes).
         """
-        self = single_gpu_model(self)
+        if self.is_multi_gpu:
+            raise ValueError(
+                "MirroredStrategy is not supported for this method. "
+                + "Please load a new model with "
+                + "osl_dynamics.models.load(..., single_gpu=True)."
+            )
+
         if self.config.multiple_dynamics:
             return self.get_mode_time_courses(
                 dataset,
@@ -656,7 +674,13 @@ class VariationalInferenceModelBase(ModelBase):
             Gamma time course with shape (n_subjects, n_samples, n_modes) or
             (n_samples, n_modes).
         """
-        self = single_gpu_model(self)
+        if self.is_multi_gpu:
+            raise ValueError(
+                "MirroredStrategy is not supported for this method. "
+                + "Please load a new model with "
+                + "osl_dynamics.models.load(..., single_gpu=True)."
+            )
+
         if not self.config.multiple_dynamics:
             raise ValueError("Please use get_alpha for a single time scale model.")
 
@@ -721,7 +745,13 @@ class VariationalInferenceModelBase(ModelBase):
         kl_loss : float
             KL divergence loss.
         """
-        self = single_gpu_model(self)
+        if self.is_multi_gpu:
+            raise ValueError(
+                "MirroredStrategy is not supported for this method. "
+                + "Please load a new model with "
+                + "osl_dynamics.models.load(..., single_gpu=True)."
+            )
+
         dataset = self.make_dataset(dataset, concatenate=True)
         _logger.info("Getting losses")
         predictions = self.predict(dataset, **kwargs)
@@ -931,7 +961,13 @@ class MarkovStateInferenceModelBase(ModelBase):
             State probabilities with shape (n_subjects, n_samples, n_states)
             or (n_samples, n_states).
         """
-        self = single_gpu_model(self)
+        if self.is_multi_gpu:
+            raise ValueError(
+                "MirroredStrategy is not supported for this method. "
+                + "Please load a new model with "
+                + "osl_dynamics.models.load(..., single_gpu=True)."
+            )
+
         if remove_edge_effects:
             step_size = self.config.sequence_length // 2  # 50% overlap
         else:
@@ -1307,7 +1343,13 @@ class MarkovStateInferenceModelBase(ModelBase):
 
             return first_term + remaining_terms
 
-        self = single_gpu_model(self)
+        if self.is_multi_gpu:
+            raise ValueError(
+                "MirroredStrategy is not supported for this method. "
+                + "Please load a new model with "
+                + "osl_dynamics.models.load(..., single_gpu=True)."
+            )
+
         dataset = self.make_dataset(dataset, concatenate=False)
         _logger.info("Getting free energy")
         free_energy = []

--- a/osl_dynamics/models/inf_mod_base.py
+++ b/osl_dynamics/models/inf_mod_base.py
@@ -16,7 +16,7 @@ import osl_dynamics.data.tf as dtf
 from osl_dynamics.simulation import HMM
 from osl_dynamics.inference import callbacks, optimizers
 from osl_dynamics.inference.initializers import WeightInitializer
-from osl_dynamics.models.mod_base import ModelBase
+from osl_dynamics.models.mod_base import ModelBase, single_gpu_model
 from osl_dynamics.utils.misc import replace_argument
 
 _logger = logging.getLogger("osl-dynamics")
@@ -211,6 +211,7 @@ class VariationalInferenceModelBase(ModelBase):
             training_data,
             shuffle=True,
             concatenate=True,
+            drop_last_batch=True,
         )
 
         # Calculate the number of batches to use
@@ -223,12 +224,6 @@ class VariationalInferenceModelBase(ModelBase):
         for n in range(n_init):
             _logger.info(f"Initialization {n}")
             self.reset()
-
-            training_dataset = self.make_dataset(
-                training_data,
-                shuffle=True,
-                concatenate=True,
-            )
             training_data_subset = training_dataset.shuffle(buffer_size).take(n_batches)
 
             try:
@@ -309,7 +304,9 @@ class VariationalInferenceModelBase(ModelBase):
         )
 
         # Make a list of tensorflow Datasets if the data
-        training_data = self.make_dataset(training_data, shuffle=True)
+        training_data = self.make_dataset(
+            training_data, shuffle=True, drop_last_batch=True
+        )
 
         if not isinstance(training_data, list):
             raise ValueError(
@@ -448,6 +445,7 @@ class VariationalInferenceModelBase(ModelBase):
             Mode mixing logits for FC.
             Only returned if :code:`self.config.multiple_dynamics=True`.
         """
+        self = single_gpu_model(self)
         if self.config.multiple_dynamics:
             return self.get_mode_logits(
                 dataset,
@@ -516,6 +514,7 @@ class VariationalInferenceModelBase(ModelBase):
             Mode mixing logits for FC with shape (n_subjects, n_samples,
             n_modes) or (n_samples, n_modes).
         """
+        self = single_gpu_model(self)
         if not self.config.multiple_dynamics:
             raise ValueError("Please use get_theta for a single time scale model.")
 
@@ -586,6 +585,7 @@ class VariationalInferenceModelBase(ModelBase):
             Mode mixing coefficients with shape (n_subjects, n_samples,
             n_modes) or (n_samples, n_modes).
         """
+        self = single_gpu_model(self)
         if self.config.multiple_dynamics:
             return self.get_mode_time_courses(
                 dataset,
@@ -656,6 +656,7 @@ class VariationalInferenceModelBase(ModelBase):
             Gamma time course with shape (n_subjects, n_samples, n_modes) or
             (n_samples, n_modes).
         """
+        self = single_gpu_model(self)
         if not self.config.multiple_dynamics:
             raise ValueError("Please use get_alpha for a single time scale model.")
 
@@ -720,6 +721,7 @@ class VariationalInferenceModelBase(ModelBase):
         kl_loss : float
             KL divergence loss.
         """
+        self = single_gpu_model(self)
         dataset = self.make_dataset(dataset, concatenate=True)
         _logger.info("Getting losses")
         predictions = self.predict(dataset, **kwargs)
@@ -929,6 +931,7 @@ class MarkovStateInferenceModelBase(ModelBase):
             State probabilities with shape (n_subjects, n_samples, n_states)
             or (n_samples, n_states).
         """
+        self = single_gpu_model(self)
         if remove_edge_effects:
             step_size = self.config.sequence_length // 2  # 50% overlap
         else:
@@ -1049,7 +1052,7 @@ class MarkovStateInferenceModelBase(ModelBase):
 
         # Make a TensorFlow Dataset
         training_dataset = self.make_dataset(
-            training_data, shuffle=True, concatenate=True
+            training_data, shuffle=True, concatenate=True, drop_last_batch=True
         )
 
         # Calculate the number of batches to use
@@ -1062,10 +1065,6 @@ class MarkovStateInferenceModelBase(ModelBase):
         for n in range(n_init):
             _logger.info(f"Initialization {n}")
             self.reset()
-
-            training_dataset = self.make_dataset(
-                training_data, shuffle=True, concatenate=True
-            )
             training_data_subset = training_dataset.shuffle(buffer_size).take(n_batches)
 
             try:
@@ -1134,7 +1133,7 @@ class MarkovStateInferenceModelBase(ModelBase):
 
         # Make a TensorFlow Dataset
         training_dataset = self.make_dataset(
-            training_data, shuffle=True, concatenate=True
+            training_data, shuffle=True, concatenate=True, drop_last_batch=True
         )
 
         # Calculate the number of batches to use
@@ -1147,10 +1146,6 @@ class MarkovStateInferenceModelBase(ModelBase):
         for n in range(n_init):
             _logger.info(f"Initialization {n}")
             self.reset()
-
-            training_dataset = self.make_dataset(
-                training_data, shuffle=True, concatenate=True
-            )
             training_data_subset = training_dataset.shuffle(buffer_size).take(n_batches)
 
             self.set_random_state_time_course_initialization(training_data_subset)
@@ -1188,7 +1183,9 @@ class MarkovStateInferenceModelBase(ModelBase):
         _logger.info("Setting random means and covariances")
 
         # Make a TensorFlow Dataset
-        training_dataset = self.make_dataset(training_data, concatenate=True)
+        training_dataset = self.make_dataset(
+            training_data, concatenate=True, drop_last_batch=True
+        )
 
         # Mean and covariance for each state
         means = np.zeros(
@@ -1310,6 +1307,7 @@ class MarkovStateInferenceModelBase(ModelBase):
 
             return first_term + remaining_terms
 
+        self = single_gpu_model(self)
         dataset = self.make_dataset(dataset, concatenate=False)
         _logger.info("Getting free energy")
         free_energy = []


### PR DESCRIPTION
Changes
- Use of TFRecords no longer trigger error in later TF versions.
- Fixed different bugs related to using TFRecords and multiple GPUs.
- Disallow inference on multiple GPUs.
- Allow loading a model while forcing it to be compiled on a single GPU.
- Warning when using multiple GPUs but not using TFRecords.

This closes the issues #185 and #176 .