### PR TITLE
Bugs in thresholding and saving FC networks

### DIFF
--- a/osl_dynamics/analysis/connectivity.py
+++ b/osl_dynamics/analysis/connectivity.py
@@ -656,7 +656,7 @@ def threshold(
     m, n = np.triu_indices(n_channels, k=1)
 
     # Which edges are greater than the threshold?
-    edges = np.empty(
+    edges = np.zeros(
         [n_components, n_modes, n_channels, n_channels],
         dtype=bool,
     )
@@ -850,19 +850,19 @@ def save(
                 fn=Path(filename), i=i, w=len(str(n_modes))
             )
 
-            # If all connections are zero don't add a colourbar
-            kwargs["colorbar"] = np.any(
-                conn_map[i][~np.eye(conn_map[i].shape[-1], dtype=bool)] != 0
-            )
+        # If all connections are zero don't add a colourbar
+        kwargs["colorbar"] = np.any(
+            conn_map[i][~np.eye(conn_map[i].shape[-1], dtype=bool)] != 0
+        )
 
-            # Plot maps
-            plotting.plot_connectome(
-                conn_map[i],
-                parcellation.roi_centers(),
-                edge_threshold=f"{threshold[i] * 100}%",
-                output_file=output_file,
-                **kwargs,
-            )
+        # Plot maps
+        plotting.plot_connectome(
+            conn_map[i],
+            parcellation.roi_centers(),
+            edge_threshold=f"{threshold[i] * 100}%",
+            output_file=output_file,
+            **kwargs,
+        )
 
 
 def save_interactive(


### PR DESCRIPTION
In `analysis.connectivity`, I encountered likely bugs in `threshold()` and `save()` functions.

### 1. Thresholding connectivity maps
When thresholding a symmetric connectivity matrix, we exclude the diagonal elements from thresholding after turning them into `np.nan`. 

However, I noticed that since `edges` is initiated with `np.empty()`, the diagonal elements are set to either True or False depending on the memory allocation. This caused some breaks during visualization and messed up with a distribution of thresholded values. 

Three possible ways to change this are:

- Set edge values for the diagonal elements as `False`.
- Set edge values for the diagonal elements as `True`.
- Include the diagonal elements in the thresholding.

I implemented the first option, as I thought this would be most relevant to our use case.

### 2. Saving connectivity maps
Nesting the plotting portion within the if-else loop will result in the function doing nothing when `output_file=None`. I took out this part from the loop, as in the `save_interactive()` function.