### PR TITLE
Refact: Refactored code for subject embedding models.

### DIFF
--- a/examples/simulation/sedynemo_hmm-mvn.py
+++ b/examples/simulation/sedynemo_hmm-mvn.py
@@ -85,7 +85,7 @@ model.set_regularizers(training_data)
 model.set_dev_parameters_initializer(training_data)
 
 # Model initialization
-model.random_subset_initialization(training_data, n_init=5, n_epochs=3, take=0.4)
+model.random_subset_initialization(training_data, n_init=5, n_epochs=3, take=1)
 
 # Full training
 print("Training model")

--- a/osl_dynamics/inference/layers.py
+++ b/osl_dynamics/inference/layers.py
@@ -221,6 +221,24 @@ class InverseCholeskyLayer(layers.Layer):
         return self.bijector.inverse(inputs)
 
 
+class BatchSizeLayer(layers.Layer):
+    """Layer for getting the batch size.
+
+    Parameters
+    ----------
+    kwargs : keyword arguments, optional
+        Keyword arguments to pass to the base class.
+    """
+
+    def call(self, inputs):
+        """
+        Note
+        ----
+        The :code:`inputs` passed to this method are not used.
+        """
+        return tf.shape(inputs)[0]
+
+
 class SampleGammaDistributionLayer(layers.Layer):
     """Layer for sampling from a Gamma distribution.
 
@@ -246,9 +264,19 @@ class SampleGammaDistributionLayer(layers.Layer):
 
     def call(self, inputs, training=None, **kwargs):
         """This method accepts the shape and rate and outputs the samples."""
-        alpha, beta = inputs
+        alpha, beta, subj_id = inputs
+        # alpha.shape = (n_subjects, n_states, 1)
+        # beta.shape = (n_subjects, n_states, 1)
+        # subj_id.shape = (None, sequence_length)
+
+        # output.shape = (None, n_states, 1)
+
         alpha = add_epsilon(alpha, self.epsilon)
         beta = add_epsilon(beta, self.epsilon)
+        subj_id = subj_id[:, 0]  # shape = (None,)
+
+        alpha = tf.gather(alpha, subj_id, axis=0)  # shape = (None, n_states, 1)
+        beta = tf.gather(beta, subj_id, axis=0)  # shape = (None, n_states, 1)
         if training:
             output = alpha / beta
             if self.annealing_factor > 0:
@@ -1435,22 +1463,20 @@ class MixSubjectSpecificParametersLayer(layers.Layer):
     def call(self, inputs):
         # Unpack inputs:
         # - alpha.shape   = (None, sequence_length, n_modes)
-        # - mu.shape      = (n_subjects, n_modes, n_channels)
-        # - D.shape       = (n_subjects, n_modes, n_channels, n_channels)
-        # - subj_id.shape = (None, sequence_length)
-        alpha, mu, D, subj_id = inputs
-        subj_id = tf.cast(subj_id, tf.int32)
+        # - mu.shape      = (None, n_modes, n_channels)
+        # - D.shape       = (None, n_modes, n_channels, n_channels)
+        alpha, mu, D = inputs
 
-        # The parameters for each time point
-        dynamic_mu = tf.gather(mu, subj_id)
-        dynamic_D = tf.gather(D, subj_id)
+        # Add the sequence dimension
+        mu = tf.expand_dims(mu, axis=1)
+        D = tf.expand_dims(D, axis=1)
 
         # Next mix with the time course
         alpha = tf.expand_dims(alpha, axis=-1)
-        m = tf.reduce_sum(tf.multiply(alpha, dynamic_mu), axis=2)
+        m = tf.reduce_sum(tf.multiply(alpha, mu), axis=2)
 
         alpha = tf.expand_dims(alpha, axis=-1)
-        C = tf.reduce_sum(tf.multiply(alpha, dynamic_D), axis=2)
+        C = tf.reduce_sum(tf.multiply(alpha, D), axis=2)
 
         return m, C
 
@@ -1824,16 +1850,17 @@ class SeparateLogLikelihoodLayer(layers.Layer):
         self.epsilon = epsilon
 
     def call(self, inputs, **kwargs):
-        x, mu, sigma, subj_id = inputs
+        x, mu, sigma = inputs
+        # x.shape = (None, sequence_length, n_channels)
+        # mu.shape = (None, n_states, n_channels)
+        # sigma.shape = (None, n_states, n_channels, n_channels)
         sigma = add_epsilon(sigma, self.epsilon, diag=True)
 
-        if subj_id is None:
-            n_states = tf.shape(mu)[0]
-        else:
-            n_states = tf.shape(mu)[1]
-            subj_id = tf.cast(subj_id, tf.int32)
-            mu = tf.gather(mu, subj_id)
-            sigma = tf.gather(sigma, subj_id)
+        n_states = tf.shape(mu)[1]
+
+        # add the sequence dimension
+        mu = tf.expand_dims(mu, axis=1)
+        sigma = tf.expand_dims(sigma, axis=1)
 
         # Calculate log-likelihood for each state
         log_likelihood = tf.TensorArray(tf.float32, size=n_states)

--- a/osl_dynamics/models/obs_mod.py
+++ b/osl_dynamics/models/obs_mod.py
@@ -510,7 +510,8 @@ def get_dev_mag(model, map):
         dev_mag_layer = model.get_layer("covs_dev_mag")
     else:
         raise ValueError("map must be either 'means' or 'covs'")
-    dev_mag = dev_mag_layer([alpha, beta])
+    n_subjects = alpha.shape[0]
+    dev_mag = dev_mag_layer([alpha, beta, np.arange(n_subjects)[:, None]])
     return dev_mag.numpy()
 
 


### PR DESCRIPTION
Improvement to subject embedding models. 

- The code now exploits the fact that each sequence can only come from the same subject and only assign one set of observation model parameters to each sequence.
- This avoids the need to assign memory to observation model parameters (especially covariances) to every single time point.
- Training is ~5 times faster.
- Memory consumption reduced significantly (more than 5 fold and can reach 10 fold in some cases).
- The code decouples memory consumption with the number of subject.
- The code also samples different deviations for different sequences in a batch, which leads to smaller variance of the MC estimator of the gradient during re-param trick.
- The HMM intialisation step is removed from the wrapper as it's no longer needed for convergence purpose due to the above change.