### PR TITLE
Feat: Allow extra session labels as extra channels in Data class.

### DIFF
--- a/examples/simulation/dive_hmm-mvn.py
+++ b/examples/simulation/dive_hmm-mvn.py
@@ -72,7 +72,10 @@ sim = simulation.MSess_HMM_MVN(
     random_seed=1234,
 )
 sim.standardize()
-training_data = data.Data(sim.time_series)
+training_data = data.Data(
+    sim.time_series,
+    session_labels={"session_id": np.arange(config.n_sessions)},
+)
 
 # Build model
 model = Model(config)

--- a/examples/simulation/hive_hmm-mvn.py
+++ b/examples/simulation/hive_hmm-mvn.py
@@ -68,7 +68,10 @@ sim.standardize()
 sim_stc = np.concatenate(sim.mode_time_course)
 
 # Create training dataset
-training_data = data.Data(sim.time_series)
+training_data = data.Data(
+    sim.time_series,
+    session_labels={"session_id": np.arange(config.n_sessions)},
+)
 
 # Build model
 model = Model(config)


### PR DESCRIPTION
This allows extra information (session labels) to be added as extra channels to the Data class.

- the previous `session_id` channel has been removed by default.
- To add session labels, it can be passed as arguments (`training_data = Data(..., session_labels={"session_id": np.arange(n_sessions)})`).