### PR TITLE
TFRecords improvement

### DIFF
--- a/osl_dynamics/data/__init__.py
+++ b/osl_dynamics/data/__init__.py
@@ -10,6 +10,6 @@ New users may find the following tutorials helpful:
   /tutorials_build/data_preparation.html>`_
 """
 
-from osl_dynamics.data.base import Data
+from osl_dynamics.data.base import Data, load_tfrecord_dataset
 
 __all__ = ["Data"]

--- a/osl_dynamics/data/base.py
+++ b/osl_dynamics/data/base.py
@@ -1296,11 +1296,15 @@ class Data:
 
         # Helper function for parsing training examples
         def _parse_example(example):
-            feature_names = ["data", "session_id"]
+            feature_names = ["data"]
             tensor_shapes = {
                 "data": [self.sequence_length, self.n_channels],
-                "session_id": [self.sequence_length],
             }
+            # Add session labels if there are any
+            for feature_name in self.session_labels.keys():
+                feature_names.append(feature_name)
+                tensor_shapes[feature_name] = [self.sequence_length]
+
             feature_description = {
                 name: tf.io.FixedLenFeature([], tf.string) for name in feature_names
             }

--- a/osl_dynamics/data/tf.py
+++ b/osl_dynamics/data/tf.py
@@ -72,18 +72,6 @@ def create_dataset(data, sequence_length, step_size):
         dataset = Dataset.from_tensor_slices(data)
         dataset = dataset.batch(sequence_length, drop_remainder=True)
 
-    # Create an overlapping single model input dataset
-    elif len(data) == 1:
-        dataset = Dataset.from_tensor_slices(list(data.values())[0])
-        dataset = dataset.window(
-            sequence_length,
-            step_size,
-            drop_remainder=True,
-        )
-        dataset = dataset.flat_map(
-            lambda window: window.batch(sequence_length, drop_remainder=True)
-        )
-
     # Create an overlapping multiple model input dataset
     else:
 


### PR DESCRIPTION
Closes https://github.com/OHBA-analysis/osl-dynamics/issues/230.

Several improvements related to the use of TFRecords.

- added `overwrite` argument to indicate whether to overwrite the tfrecord files when tfrecord config is not the same. This solves issue #181 .
- added method to save tfrecord files and function to load tfrecord files as a TF Dataset object, which could be passed to `model.fit` or `model.predict` direclty. This solves issue #230 .
- This PR also fixes some minor bugs.

To save a TFRecord dataset:
```
from osl_dynamics.data import Data

data = Data(...)
data.save_tfrecord_dataset("path_to_directory")
```
Note if `overwrite=False` and a previous `tfrecord_config.pkl` exists, the files won't be rewritten.

To load a TFRecord dataset:
```
from osl_dynamics.data import load_tfrecord_dataset

dataset = load_tfrecord_dataset("path_to_directory", batch_size=batch_size)

# Then it can be passed directly to train a model
model.fit(dataset)
```