### PR TITLE
Enhancement related to TFRecords

### DIFF
--- a/osl_dynamics/data/tf.py
+++ b/osl_dynamics/data/tf.py
@@ -142,6 +142,22 @@ def save_tfrecord(data, sequence_length, step_size, filepath):
             writer.write(_make_example(sequence))
 
 
+def _validate_tf_dataset(dataset):
+    """Check if the input is a valid TensorFlow dataset."""
+    import tensorflow as tf  # avoid slow imports
+
+    if isinstance(dataset, list):
+        if len(dataset) == 1:
+            dataset = dataset[0]
+        else:
+            dataset = concatenate_datasets(dataset)
+
+    if not isinstance(dataset, tf.data.Dataset):
+        raise ValueError("dataset must be a TensorFlow dataset or a list of datasets")
+
+    return dataset
+
+
 def get_range(dataset):
     """The range (max-min) of values contained in a batched Tensorflow dataset.
 
@@ -157,6 +173,7 @@ def get_range(dataset):
     """
     amax = []
     amin = []
+    dataset = _validate_tf_dataset(dataset)
     for batch in dataset:
         if isinstance(batch, dict):
             batch = batch["data"]
@@ -181,6 +198,7 @@ def get_n_channels(dataset):
     n_channels : int
         Number of channels.
     """
+    dataset = _validate_tf_dataset(dataset)
     for batch in dataset:
         if isinstance(batch, dict):
             batch = batch["data"]
@@ -203,15 +221,7 @@ def get_n_batches(dataset):
     """
     import tensorflow as tf  # avoid slow imports
 
-    if isinstance(dataset, list):
-        if len(dataset) == 1:
-            dataset = dataset[0]
-        else:
-            dataset = concatenate_datasets(dataset)
-
-    if not isinstance(dataset, tf.data.Dataset):
-        raise ValueError("dataset must be a TensorFlow dataset or a list of datasets")
-
+    dataset = _validate_tf_dataset(dataset)
     # Count number of batches
     cardinality = dataset.cardinality()
     if cardinality == tf.data.UNKNOWN_CARDINALITY:

--- a/osl_dynamics/models/dive.py
+++ b/osl_dynamics/models/dive.py
@@ -421,14 +421,24 @@ class Model(VariationalInferenceModelBase):
                 layer_name="group_covs",
             )
 
-    def set_dev_parameters_initializer(self, training_dataset):
+    def set_dev_parameters_initializer(self, training_data):
         """Set the deviance parameters initializer based on training data.
 
         Parameters
         ----------
-        training_dataset : osl_dynamics.data.Data
-            The training dataset.
+        training_data : osl_dynamics.data.Data or tf.data.Dataset
+            The training data.
         """
+        training_dataset = self.make_dataset(
+            training_data,
+            shuffle=False,
+            concatenate=False,
+        )
+        if len(training_dataset) != self.config.n_sessions:
+            raise ValueError(
+                "The number of sessions in the training data must match "
+                "the number of sessions in the model."
+            )
         obs_mod.set_dev_parameters_initializer(
             self.model,
             training_dataset,

--- a/osl_dynamics/models/dynemo.py
+++ b/osl_dynamics/models/dynemo.py
@@ -590,10 +590,18 @@ class Model(VariationalInferenceModelBase):
         means = []
         covariances = []
         with self.set_trainable(fixed_layers, False):
-            for i in trange(training_data.n_sessions, desc="Dual estimation"):
+            if isinstance(training_data, list):
+                n_sessions = len(training_data)
+            else:
+                n_sessions = training_data.n_sessions
+
+            for i in trange(n_sessions, desc="Dual estimation"):
                 # Train on this session
-                with training_data.set_keep(i):
-                    self.fit(training_data, verbose=0)
+                if isinstance(training_data, list):
+                    self.fit(training_data[i], verbose=0)
+                else:
+                    with training_data.set_keep(i):
+                        self.fit(training_data, verbose=0)
 
                 # Get inferred parameters
                 m, c = self.get_means_covariances()

--- a/osl_dynamics/models/hive.py
+++ b/osl_dynamics/models/hive.py
@@ -559,14 +559,25 @@ class Model(MarkovStateInferenceModelBase):
                 layer_name="group_covs",
             )
 
-    def set_dev_parameters_initializer(self, training_dataset):
+    def set_dev_parameters_initializer(self, training_data):
         """Set the deviance parameters initializer based on training data.
 
         Parameters
         ----------
-        training_dataset : osl_dynamics.data.Data
-            The training dataset.
+        training_data : osl_dynamics.data.Data or tf.data.Dataset
+            The training data.
         """
+        training_dataset = self.make_dataset(
+            training_data,
+            shuffle=False,
+            concatenate=False,
+        )
+        if len(training_dataset) != self.config.n_sessions:
+            raise ValueError(
+                "The number of sessions in the training data must match "
+                "the number of sessions in the model."
+            )
+
         obs_mod.set_dev_parameters_initializer(
             self.model,
             training_dataset,

--- a/osl_dynamics/models/hmm.py
+++ b/osl_dynamics/models/hmm.py
@@ -1399,7 +1399,7 @@ class Model(ModelBase):
 
         Parameters
         ----------
-        training_data : osl_dynamics.data.Data
+        training_data : osl_dynamics.data.Data or list of tf.data.Dataset
             Prepared training data object.
         alpha : list of np.ndarray, optional
             Posterior distribution of the states. Shape is
@@ -1424,7 +1424,15 @@ class Model(ModelBase):
             alpha = [alpha]
 
         # Get the session-specific data
-        data = training_data.time_series(prepared=True, concatenate=False)
+        if isinstance(training_data, list):
+            data = []
+            for d in training_data:
+                subject_data = []
+                for batch in d:
+                    subject_data.append(np.concatenate(batch["data"]))
+                data.append(np.concatenate(subject_data))
+        else:
+            data = training_data.time_series(prepared=True, concatenate=False)
 
         if len(alpha) != len(data):
             raise ValueError(

--- a/osl_dynamics/models/obs_mod.py
+++ b/osl_dynamics/models/obs_mod.py
@@ -113,15 +113,21 @@ def set_dev_parameters_initializer(
     ----------
     model : osl_dynamics.models.*.Model.model
         The model. * must be :code:`hive` or :code:`dive`.
-    training_dataset : osl_dynamics.data.Data
+    training_dataset : tf.data.Dataset
         The training dataset.
     learn_means : bool
         Whether the mean is learnt.
     learn_covariances : bool
         Whether the covariances are learnt.
     """
-    time_series = training_dataset.time_series()
-    n_channels = training_dataset.n_channels
+    time_series = []
+    for d in training_dataset:
+        subject_data = []
+        for batch in d:
+            subject_data.append(np.concatenate(batch["data"]))
+        time_series.append(np.concatenate(subject_data))
+
+    n_channels = time_series[0].shape[1]
     if isinstance(time_series, np.ndarray):
         time_series = [time_series]
     if learn_means:


### PR DESCRIPTION
This PR allows TFRecords/`tf.data.Dataset` to be passed as inputs to several methods including:

- `model.set_regularizers`
- `obs_mod.set_dev_parameters_initializer`
- `hmm.Model.dual_estimation`
- `dynemo.Model.dual_estimation`