### PR TITLE
Option to specify random seed

### DIFF
--- a/examples/simulation/dive_hmm-mvn.py
+++ b/examples/simulation/dive_hmm-mvn.py
@@ -69,7 +69,6 @@ sim = simulation.MSess_HMM_MVN(
     n_groups=3,
     between_group_scale=0.2,
     stay_prob=0.9,
-    random_seed=1234,
 )
 sim.standardize()
 training_data = data.Data(sim.time_series)

--- a/examples/simulation/dynemo_hmm-mvn.py
+++ b/examples/simulation/dynemo_hmm-mvn.py
@@ -30,7 +30,6 @@ sim = HMM_MVN(
     stay_prob=0.9,
     means="zero",
     covariances="random",
-    random_seed=123,
 )
 
 # Create Data object for training

--- a/examples/simulation/dynemo_hmm-mvn_high-n-modes.py
+++ b/examples/simulation/dynemo_hmm-mvn_high-n-modes.py
@@ -43,7 +43,6 @@ sim = simulation.HMM_MVN(
     stay_prob=0.9,
     means="zero",
     covariances="random",
-    random_seed=123,
 )
 sim.standardize()
 training_data = data.Data(sim.time_series)

--- a/examples/simulation/dynemo_long-range-dep1.py
+++ b/examples/simulation/dynemo_long-range-dep1.py
@@ -50,7 +50,6 @@ sim = simulation.HSMM_MVN(
     observation_error=0.0,
     gamma_shape=10,
     gamma_scale=5,
-    random_seed=123,
 )
 sim.standardize()
 training_data = data.Data(sim.time_series)

--- a/examples/simulation/dynemo_long-range-dep2.py
+++ b/examples/simulation/dynemo_long-range-dep2.py
@@ -84,9 +84,6 @@ sim = HierarchicalHMM_MVN(
     bottom_level_trans_probs=bottom_level_trans_probs,
     means="zero",
     covariances="random",
-    top_level_random_seed=123,
-    bottom_level_random_seeds=[124, 126, 127],
-    data_random_seed=555,
 )
 sim.standardize()
 training_data = Data(sim.time_series)

--- a/examples/simulation/dynemo_soft-mixing.py
+++ b/examples/simulation/dynemo_soft-mixing.py
@@ -52,7 +52,6 @@ sim = simulation.MixedSine_MVN(
     sampling_frequency=250,
     means="zero",
     covariances="random",
-    random_seed=123,
 )
 sim_alp = sim.mode_time_course
 training_data = data.Data(sim.time_series)

--- a/examples/simulation/hive_hmm-mvn.py
+++ b/examples/simulation/hive_hmm-mvn.py
@@ -63,7 +63,6 @@ sim = simulation.MSess_HMM_MVN(
     n_groups=3,
     between_group_scale=0.2,
     stay_prob=0.9,
-    random_seed=1234,
 )
 sim.standardize()
 sim_stc = np.concatenate(sim.mode_time_course)

--- a/examples/simulation/hmm-poi_hmm-poi.py
+++ b/examples/simulation/hmm-poi_hmm-poi.py
@@ -27,7 +27,6 @@ sim = HMM_Poi(
     n_channels=11,
     trans_prob="sequence",
     stay_prob=0.9,
-    random_seed=123,
 )
 
 # Create Data object for training

--- a/examples/simulation/hmm_hmm-mvn.py
+++ b/examples/simulation/hmm_hmm-mvn.py
@@ -30,7 +30,6 @@ sim = HMM_MVN(
     stay_prob=0.9,
     means="zero",
     covariances="random",
-    random_seed=123,
 )
 
 # Create Data object for training

--- a/examples/simulation/hmm_hmm-mvn_fisher-kernel.py
+++ b/examples/simulation/hmm_hmm-mvn_fisher-kernel.py
@@ -40,7 +40,6 @@ sim = simulation.MSess_HMM_MVN(
     n_groups=3,
     between_group_scale=0.2,
     stay_prob=0.9,
-    random_seed=1234,
 )
 sim.standardize()
 

--- a/examples/simulation/hmm_tinda.py
+++ b/examples/simulation/hmm_tinda.py
@@ -23,7 +23,6 @@ sim = simulation.HMM_MVN(
     stay_prob=0.9,
     means="zero",
     covariances="random",
-    random_seed=42,
 )
 sim_stc = sim.state_time_course
 

--- a/examples/simulation/mdynemo_hmm-mvn.py
+++ b/examples/simulation/mdynemo_hmm-mvn.py
@@ -50,7 +50,6 @@ sim = simulation.MDyn_HMM_MVN(
     stay_prob=0.9,
     means="random",
     covariances="random",
-    random_seed=123,
 )
 sim.standardize()
 training_data = data.Data(sim.time_series)

--- a/examples/simulation/state-dynemo_hmm-mvn.py
+++ b/examples/simulation/state-dynemo_hmm-mvn.py
@@ -40,7 +40,6 @@ sim = simulation.HMM_MVN(
     stay_prob=0.9,
     means="zero",
     covariances="random",
-    random_seed=123,
 )
 sim.standardize()
 training_data = data.Data(sim.time_series)

--- a/examples/simulation/state-dynemo_hmm-mvn_high-n-states.py
+++ b/examples/simulation/state-dynemo_hmm-mvn_high-n-states.py
@@ -40,7 +40,6 @@ sim = simulation.HMM_MVN(
     stay_prob=0.9,
     means="zero",
     covariances="random",
-    random_seed=123,
 )
 sim.standardize()
 training_data = data.Data(sim.time_series)

--- a/osl_dynamics/simulation/hmm.py
+++ b/osl_dynamics/simulation/hmm.py
@@ -30,8 +30,6 @@ class HMM:
     n_states : int, optional
         Number of states. Needed when :code:`trans_prob` is a :code:`str` to
         construct the transition probability matrix.
-    random_seed : int, optional
-        Seed for random number generator.
     """
 
     def __init__(
@@ -39,7 +37,6 @@ class HMM:
         trans_prob,
         stay_prob=None,
         n_states=None,
-        random_seed=None,
     ):
         if isinstance(trans_prob, list):
             trans_prob = np.ndarray(trans_prob)
@@ -112,9 +109,6 @@ class HMM:
         # Infer number of states from the transition probability matrix
         self.n_states = self.trans_prob.shape[0]
 
-        # Setup random number generator
-        self._rng = np.random.default_rng(random_seed)
-
     @staticmethod
     def construct_sequence_trans_prob(stay_prob, n_states):
         trans_prob = np.zeros([n_states, n_states])
@@ -133,7 +127,7 @@ class HMM:
     def generate_states(self, n_samples):
         # Here the time course always start from state 0
         rands = [
-            iter(self._rng.choice(self.n_states, size=n_samples, p=self.trans_prob[i]))
+            iter(np.random.choice(self.n_states, size=n_samples, p=self.trans_prob[i]))
             for i in range(self.n_states)
         ]
         states = np.zeros(n_samples, int)
@@ -165,8 +159,6 @@ class HMM_MAR(Simulation):
     stay_prob : float, optional
         Used to generate the transition probability matrix is
         :code:`trans_prob` is a :code:`str`. Must be between 0 and 1.
-    random_seed : int, optional
-        Seed for random number generator.
     """
 
     def __init__(
@@ -176,10 +168,9 @@ class HMM_MAR(Simulation):
         coeffs,
         covs,
         stay_prob=None,
-        random_seed=None,
     ):
         # Observation model
-        self.obs_mod = MAR(coeffs=coeffs, covs=covs, random_seed=random_seed)
+        self.obs_mod = MAR(coeffs=coeffs, covs=covs)
 
         self.n_states = self.obs_mod.n_states
         self.n_channels = self.obs_mod.n_channels
@@ -190,7 +181,6 @@ class HMM_MAR(Simulation):
             trans_prob=trans_prob,
             stay_prob=stay_prob,
             n_states=self.n_states,
-            random_seed=random_seed if random_seed is None else random_seed + 1,
         )
 
         # Initialise base class
@@ -246,8 +236,6 @@ class HMM_MVN(Simulation):
         is a :code:`str`. Must be between 0 and 1.
     observation_error : float, optional
         Standard deviation of the error added to the generated data.
-    random_seed : int, optional
-        Seed for random number generator.
     """
 
     def __init__(
@@ -262,7 +250,6 @@ class HMM_MVN(Simulation):
         n_covariances_act=1,
         stay_prob=None,
         observation_error=0.0,
-        random_seed=None,
     ):
         if n_states is None:
             n_states = n_modes
@@ -275,7 +262,6 @@ class HMM_MVN(Simulation):
             n_channels=n_channels,
             n_covariances_act=n_covariances_act,
             observation_error=observation_error,
-            random_seed=random_seed,
         )
 
         self.n_states = self.obs_mod.n_modes
@@ -287,7 +273,6 @@ class HMM_MVN(Simulation):
             trans_prob=trans_prob,
             stay_prob=stay_prob,
             n_states=self.n_states,
-            random_seed=random_seed if random_seed is None else random_seed + 1,
         )
 
         # Initialise base class
@@ -365,8 +350,6 @@ class MDyn_HMM_MVN(Simulation):
         is a :code:`str`. Must be between 0 and 1.
     observation_error : float, optional
         Standard deviation of the error added to the generated data.
-    random_seed : int, optional
-        Seed for random number generator.
     """
 
     def __init__(
@@ -381,7 +364,6 @@ class MDyn_HMM_MVN(Simulation):
         n_covariances_act=1,
         stay_prob=None,
         observation_error=0.0,
-        random_seed=None,
     ):
         if n_states is None:
             n_states = n_modes
@@ -394,7 +376,6 @@ class MDyn_HMM_MVN(Simulation):
             n_channels=n_channels,
             n_covariances_act=n_covariances_act,
             observation_error=observation_error,
-            random_seed=random_seed,
         )
 
         self.n_states = self.obs_mod.n_modes
@@ -406,13 +387,11 @@ class MDyn_HMM_MVN(Simulation):
             trans_prob=trans_prob,
             stay_prob=stay_prob,
             n_states=self.n_states,
-            random_seed=random_seed if random_seed is None else random_seed + 1,
         )
         self.gamma_hmm = HMM(
             trans_prob=trans_prob,
             stay_prob=stay_prob,
             n_states=self.n_states,
-            random_seed=random_seed if random_seed is None else random_seed + 2,
         )
 
         # Initialise base class
@@ -476,8 +455,6 @@ class HMM_Poi(Simulation):
         Shape must be (n_states, n_channels).
     stay_prob : float
         Used to generate the transition probability matrix is trans_prob is a str.
-    random_seed : int
-        Seed for random number generator.
     """
 
     def __init__(
@@ -488,14 +465,12 @@ class HMM_Poi(Simulation):
         n_states=None,
         n_channels=None,
         stay_prob=None,
-        random_seed=None,
     ):
         # Observation model
         self.obs_mod = Poisson(
             rates=rates,
             n_states=n_states,
             n_channels=n_channels,
-            random_seed=random_seed,
         )
 
         self.n_states = self.obs_mod.n_states
@@ -507,7 +482,6 @@ class HMM_Poi(Simulation):
             trans_prob=trans_prob,
             stay_prob=stay_prob,
             n_states=self.n_states,
-            random_seed=random_seed if random_seed is None else random_seed + 1,
         )
 
         # Initialise base class
@@ -583,8 +557,6 @@ class MSess_HMM_MVN(Simulation):
         Standard deviation when generating session-specific stay probability.
     observation_error : float, optional
         Standard deviation of the error added to the generated data.
-    random_seed : int, optional
-        Seed for random number generator.
     """
 
     def __init__(
@@ -606,7 +578,6 @@ class MSess_HMM_MVN(Simulation):
         tc_std=0.0,
         stay_prob=None,
         observation_error=0.0,
-        random_seed=None,
     ):
         if n_states is None:
             n_states = n_modes
@@ -629,7 +600,6 @@ class MSess_HMM_MVN(Simulation):
             n_groups=n_groups,
             between_group_scale=between_group_scale,
             observation_error=observation_error,
-            random_seed=random_seed,
         )
 
         self.n_states = self.obs_mod.n_modes
@@ -638,7 +608,7 @@ class MSess_HMM_MVN(Simulation):
 
         # Vary the stay probability for each session
         if stay_prob is not None:
-            session_stay_prob = self.obs_mod._rng.normal(
+            session_stay_prob = np.random.normal(
                 loc=stay_prob,
                 scale=tc_std,
                 size=self.n_sessions,
@@ -662,7 +632,6 @@ class MSess_HMM_MVN(Simulation):
                 trans_prob=trans_prob[i],
                 stay_prob=session_stay_prob[i],
                 n_states=self.n_states,
-                random_seed=random_seed if random_seed is None else random_seed + 1 + i,
             )
             self.hmm.append(hmm)
             self.state_time_course.append(hmm.generate_states(self.n_samples))
@@ -742,12 +711,6 @@ class HierarchicalHMM_MVN(Simulation):
         Number of iterations to add activations to covariance matrices.
     observation_error : float, optional
         Standard deviation of random noise to be added to the observations.
-    top_level_random_seed : int, optional
-        Random seed for generating the state time course of the top level HMM.
-    bottom_level_random_seeds : list of int, optional
-        Random seeds for the bottom level HMMs.
-    data_random_seed : int, optional
-        Random seed for generating the observed data.
     top_level_stay_prob : float, optional
         The stay_prob for the top level HMM. Used if
         :code:`top_level_trans_prob` is a :code:`str`.
@@ -779,9 +742,6 @@ class HierarchicalHMM_MVN(Simulation):
         n_channels=None,
         n_covariances_act=1,
         observation_error=0.0,
-        top_level_random_seed=None,
-        bottom_level_random_seeds=None,
-        data_random_seed=None,
         top_level_stay_prob=None,
         bottom_level_stay_probs=None,
         top_level_hmm_type="hmm",
@@ -799,7 +759,6 @@ class HierarchicalHMM_MVN(Simulation):
             n_channels=n_channels,
             n_covariances_act=n_covariances_act,
             observation_error=observation_error,
-            random_seed=data_random_seed,
         )
 
         self.n_states = self.obs_mod.n_modes
@@ -808,15 +767,11 @@ class HierarchicalHMM_MVN(Simulation):
         if bottom_level_stay_probs is None:
             bottom_level_stay_probs = [None] * len(bottom_level_trans_probs)
 
-        if bottom_level_random_seeds is None:
-            bottom_level_random_seeds = [None] * len(bottom_level_trans_probs)
-
         # Top level HMM
         # This will select the bottom level HMM at each time point
         if top_level_hmm_type.lower() == "hmm":
             self.top_level_hmm = HMM(
                 trans_prob=top_level_trans_prob,
-                random_seed=top_level_random_seed,
                 stay_prob=top_level_stay_prob,
                 n_states=len(bottom_level_trans_probs),
             )
@@ -825,7 +780,6 @@ class HierarchicalHMM_MVN(Simulation):
                 gamma_shape=top_level_gamma_shape,
                 gamma_scale=top_level_gamma_scale,
                 n_states=len(bottom_level_trans_probs),
-                random_seed=top_level_random_seed,
             )
         else:
             raise ValueError(f"Unsupported top_level_hmm_type: {top_level_hmm_type}")
@@ -836,7 +790,6 @@ class HierarchicalHMM_MVN(Simulation):
         self.bottom_level_hmms = [
             HMM(
                 trans_prob=bottom_level_trans_probs[i],
-                random_seed=bottom_level_random_seeds[i],
                 stay_prob=bottom_level_stay_probs[i],
                 n_states=n_states,
             )

--- a/osl_dynamics/simulation/mar.py
+++ b/osl_dynamics/simulation/mar.py
@@ -25,15 +25,13 @@ class MAR:
     covs : np.ndarray
         Covariance of the error :math:`\epsilon_t`. Shape must be
         (n_states, n_channels) or (n_states, n_channels, n_channels).
-    random_seed: int, optional
-        Seed for the random number generator.
 
     Note
     ----
     This model is also known as VAR or MVAR.
     """
 
-    def __init__(self, coeffs, covs, random_seed=None):
+    def __init__(self, coeffs, covs):
         # Validation
         if coeffs.ndim != 4:
             raise ValueError(
@@ -58,9 +56,6 @@ class MAR:
         self.n_states = coeffs.shape[0]
         self.n_channels = coeffs.shape[2]
 
-        # Setup random number generator
-        self._rng = np.random.default_rng(random_seed)
-
     def simulate_data(self, state_time_course):
         """Simulate time series data.
 
@@ -84,7 +79,7 @@ class MAR:
         for i in range(self.n_states):
             time_points_active = state_time_course[:, i] == 1
             n_time_points_active = np.count_nonzero(time_points_active)
-            data[time_points_active] = self._rng.multivariate_normal(
+            data[time_points_active] = np.random.multivariate_normal(
                 np.zeros(self.n_channels),
                 self.covs[i],
                 size=n_time_points_active,

--- a/osl_dynamics/simulation/poi.py
+++ b/osl_dynamics/simulation/poi.py
@@ -21,8 +21,6 @@ class Poisson:
         Number of channels.
     n_modes : int
         Number of modes.
-    random_seed : int
-        Seed for the random number generator.
     """
 
     def __init__(
@@ -30,10 +28,7 @@ class Poisson:
         rates,
         n_states=None,
         n_channels=None,
-        random_seed=None,
     ):
-        self._rng = np.random.default_rng(random_seed)
-
         if isinstance(rates, np.ndarray):
             self.n_states = rates.shape[0]
             self.n_channels = rates.shape[1]
@@ -52,7 +47,7 @@ class Poisson:
     def create_rates(self, option, eps=1e-2):
         if option == "random":
             # Randomly sample the rates from a gamma distribution
-            rates = self._rng.gamma(
+            rates = np.random.gamma(
                 shape=1.0, scale=1.1, size=(self.n_states, self.n_channels)
             )
 
@@ -60,7 +55,7 @@ class Poisson:
             n_active_channels = max(1, self.n_channels // self.n_states)
             for i in range(self.n_states):
                 active_channels = np.unique(
-                    self._rng.integers(0, self.n_channels, size=n_active_channels)
+                    np.random.randint(0, self.n_channels, size=n_active_channels)
                 )
                 rates[i, active_channels] += 1
 
@@ -76,6 +71,6 @@ class Poisson:
         # Generate data
         for i in range(n_samples):
             state = np.argmax(state_time_course[i])
-            data[i] = self._rng.poisson(self.rates[state])
+            data[i] = np.random.poisson(self.rates[state])
 
         return data

--- a/osl_dynamics/simulation/sm.py
+++ b/osl_dynamics/simulation/sm.py
@@ -27,9 +27,6 @@ class MixedSine:
         Frequency of each sinusoid.
     sampling_frequency : float
         Sampling frequency.
-    random_seed : int, optional
-        Seed used for the random number generator, which is used to sample
-        an initial phase for each sinusoid.
     """
 
     def __init__(
@@ -39,7 +36,6 @@ class MixedSine:
         amplitudes,
         frequencies,
         sampling_frequency,
-        random_seed=None,
     ):
         if len(relative_activation) != n_modes:
             raise ValueError("len(relative_activation) does not match len(n_modes).")
@@ -55,11 +51,10 @@ class MixedSine:
         self.amplitudes = amplitudes
         self.frequencies = frequencies
         self.sampling_frequency = sampling_frequency
-        self._rng = np.random.default_rng(random_seed)
 
     def generate_modes(self, n_samples):
         # Simulate a random initial phase for each sinusoid
-        self.phases = self._rng.uniform(0, 2 * np.pi, self.n_modes)
+        self.phases = np.random.uniform(0, 2 * np.pi, self.n_modes)
 
         # Generator mode time courses
         self.logits = np.empty([n_samples, self.n_modes], dtype=np.float32)
@@ -112,8 +107,6 @@ class MixedSine_MVN(Simulation):
         Number of channels.
     observation_error : float, optional
         Standard deviation of the error added to the generated data.
-    random_seed : int, optional
-        Seed for random number generator.
     """
 
     def __init__(
@@ -129,7 +122,6 @@ class MixedSine_MVN(Simulation):
         n_modes=None,
         n_channels=None,
         observation_error=0.0,
-        random_seed=None,
     ):
         # Observation model
         self.obs_mod = MVN(
@@ -139,7 +131,6 @@ class MixedSine_MVN(Simulation):
             n_modes=n_modes,
             n_channels=n_channels,
             observation_error=observation_error,
-            random_seed=random_seed,
         )
 
         self.n_modes = self.obs_mod.n_modes
@@ -152,7 +143,6 @@ class MixedSine_MVN(Simulation):
             amplitudes=amplitudes,
             frequencies=frequencies,
             sampling_frequency=sampling_frequency,
-            random_seed=random_seed,
         )
 
         super().__init__(n_samples=n_samples)
@@ -227,8 +217,6 @@ class MSess_MixedSine_MVN(Simulation):
         Scale of variability between groups.
     observation_error : float, optional
         Standard deviation of the error added to the generated data.
-    random_seed : int, optional
-        Seed for random number generator.
     """
 
     def __init__(
@@ -250,7 +238,6 @@ class MSess_MixedSine_MVN(Simulation):
         n_groups=None,
         between_group_scale=None,
         observation_error=0.0,
-        random_seed=None,
     ):
         # Observation model
         self.obs_mod = MSess_MVN(
@@ -266,7 +253,6 @@ class MSess_MixedSine_MVN(Simulation):
             n_groups=n_groups,
             between_group_scale=between_group_scale,
             observation_error=observation_error,
-            random_seed=random_seed,
         )
 
         self.n_modes = self.obs_mod.n_modes
@@ -286,7 +272,6 @@ class MSess_MixedSine_MVN(Simulation):
                 amplitudes=amplitudes,
                 frequencies=frequencies,
                 sampling_frequency=sampling_frequency,
-                random_seed=random_seed,
             )
             self.sm.append(sm)
             self.mode_time_course.append(sm.generate_modes(self.n_samples))

--- a/osl_dynamics/utils/__init__.py
+++ b/osl_dynamics/utils/__init__.py
@@ -7,3 +7,5 @@ from osl_dynamics.utils import model
 from osl_dynamics.utils import parcellation
 from osl_dynamics.utils import plotting
 from osl_dynamics.utils import topoplots
+
+from osl_dynamics.utils.misc import set_random_seed

--- a/osl_dynamics/utils/misc.py
+++ b/osl_dynamics/utils/misc.py
@@ -4,7 +4,9 @@
 
 import inspect
 import logging
+import os
 import pickle
+import random
 import sys
 from copy import copy
 from pathlib import Path
@@ -417,6 +419,25 @@ def load(filename, **kwargs):
         array = np.load(filename, **kwargs)
 
     return array
+
+
+def set_random_seed(seed):
+    """Set all random seeds.
+
+    This includes Python's random module, NumPy and TensorFlow.
+
+    Parameters
+    ----------
+    seed : int
+        Random seed.
+    """
+    import tensorflow as tf  # avoids slow imports
+
+    _logger.info(f"Setting random seed to {seed}")
+
+    random.seed(seed)
+    np.random.seed(seed)
+    tf.random.set_seed(seed)
 
 
 @contextmanager


### PR DESCRIPTION
Changes:
- Removed `random_seed` argument from simulation classes.
- Added utility function `osl_dynamics.utils.misc.set_random_seed` (can be imported from `osl_dynamics.utils`) to set the python, numpy and tensorflow random seeds.

The following code can be added to the top of a script to make it completely deterministic:
```
from osl_dynamics.utils import set_random_seed

set_random_seed(0)
```