### PR TITLE
Allow unit norm embeddings.

### DIFF
--- a/examples/simulation/hive_hmm-mvn.py
+++ b/examples/simulation/hive_hmm-mvn.py
@@ -47,6 +47,7 @@ config = Config(
     kl_annealing_curve="tanh",
     kl_annealing_sharpness=10,
     n_kl_annealing_epochs=20,
+    unit_norm_embeddings=True,
 )
 
 # Simulate data

--- a/osl_dynamics/inference/layers.py
+++ b/osl_dynamics/inference/layers.py
@@ -1974,8 +1974,8 @@ class AddLayer(layers.Layer):
         return out
 
 
-class ConstrainedEmbeddingLayer(layers.Layer):
-    """Layer for unit norm constrained embeddings.
+class EmbeddingLayer(layers.Layer):
+    """Layer for embeddings.
 
     Parameters
     ----------
@@ -1983,29 +1983,34 @@ class ConstrainedEmbeddingLayer(layers.Layer):
         Input dimension.
     output_dim : int
         Output dimension.
+    unit_norm : bool, optional
+        Should the embeddings be unit norm?
     """
 
-    def __init__(self, input_dim, output_dim, **kwargs):
+    def __init__(self, input_dim, output_dim, unit_norm, **kwargs):
         super().__init__(**kwargs)
         self.embedding_layer = layers.Embedding(
             input_dim=input_dim,
             output_dim=output_dim,
         )
         self.layers = [self.embedding_layer]
+        self.unit_norm = unit_norm
 
     def call(self, inputs, **kwargs):
         output = self.embedding_layer(inputs)
 
         # Add the last element to ensure the embeddings are unit norm
-        norm_sq = tf.reduce_sum(tf.square(output), axis=-1, keepdims=True)
-        output = tf.concat([2 * output, norm_sq - 1], axis=-1) / (norm_sq + 1)
+        if self.unit_norm:
+            norm_sq = tf.reduce_sum(tf.square(output), axis=-1, keepdims=True)
+            output = tf.concat([2 * output, norm_sq - 1], axis=-1) / (norm_sq + 1)
         return output
 
     @property
     def embeddings(self):
         output = self.embedding_layer.embeddings
-        norm_sq = tf.reduce_sum(tf.square(output), axis=-1, keepdims=True)
-        output = tf.concat([2 * output, norm_sq - 1], axis=-1) / (norm_sq + 1)
+        if self.unit_norm:
+            norm_sq = tf.reduce_sum(tf.square(output), axis=-1, keepdims=True)
+            output = tf.concat([2 * output, norm_sq - 1], axis=-1) / (norm_sq + 1)
         return output
 
 

--- a/osl_dynamics/models/hive.py
+++ b/osl_dynamics/models/hive.py
@@ -29,6 +29,7 @@ from osl_dynamics.inference.layers import (
     BatchSizeLayer,
     AddLayer,
     TFConstantLayer,
+    EmbeddingLayer,
 )
 from osl_dynamics.models import obs_mod
 from osl_dynamics.models.mod_base import BaseModelConfig
@@ -77,6 +78,8 @@ class Config(BaseModelConfig, MarkovStateInferenceModelConfig):
         Number of dimensions for embeddings dimension.
     spatial_embeddings_dim : int
         Number of dimensions for spatial embeddings.
+    unit_norm_embeddings : bool
+        Should we normalize the embeddings to have unit norm?
 
     dev_n_layers : int
         Number of layers for the MLP for deviations.
@@ -151,6 +154,7 @@ class Config(BaseModelConfig, MarkovStateInferenceModelConfig):
     n_sessions: int = None
     embeddings_dim: int = None
     spatial_embeddings_dim: int = None
+    unit_norm_embeddings: bool = False
 
     # Observation model parameters
     learn_means: bool = None
@@ -642,9 +646,10 @@ def _model_structure(config):
             data
         )
         label_embeddings_layers[session_label.name] = (
-            layers.Embedding(
+            EmbeddingLayer(
                 session_label.n_classes,
                 config.embeddings_dim,
+                config.unit_norm_embeddings,
                 name=f"{session_label.name}_embeddings",
             )
             if session_label.label_type == "categorical"


### PR DESCRIPTION
This allows the unit norm constraint on embedding vectors. 
This feature is still experimental and haven't been validated.
This feature can be achieved by setting `unit_norm_embeddings = True` when defining the `config` of HIVE or DIVE.
When multiple session labels are in the model, this ensures the embedding vectors are identifiable.