### PR TITLE
Partial directed coherence

### DIFF
--- a/osl_dynamics/analysis/spectral.py
+++ b/osl_dynamics/analysis/spectral.py
@@ -903,6 +903,183 @@ def partial_coherence_spectra(cpsd, keepdims=False):
     return coherence_spectra(icpsd, keepdims=keepdims)
 
 
+def partial_directed_coherence(
+    f,
+    cpsd,
+    sampling_frequency,
+    n_iterations=100,
+    tol=1e-10,
+    keepdims=False,
+    n_jobs=1,
+):
+    """Calculate partial directed coherence from the cross power spectra.
+
+    Parameters
+    ----------
+    f : np.ndarray
+        Frequency axis. Shape is (n_freq,).
+    cpsd : np.ndarray
+        Cross power spectra.
+        Shape is (..., n_channels, n_channels, n_freq).
+    sampling_frequency : float
+        Sampling frequency (Hz).
+    n_iterations : int, optional
+        Number of iterations in the Wilson factorization of the cross
+        spectra.
+    tol : float, optional
+        Tolerance for the Wilson factorization of the cross spectra.
+    keepdims: bool, optional
+        Should we squeeze any axis of length 1?
+    n_jobs : int, optional
+        Number of parallel jobs.
+
+    Returns
+    -------
+    pdc : np.ndarray
+        Partial directed coherence spectra.
+        Shape is (..., n_channels, n_channels, n_freq).
+    """
+
+    def _plus_operator(g, m, fs, freq):
+        # Helper function for wilson_factorization
+        N = freq.shape[0] - 1
+        gam = np.zeros([m, m, 2 * N]) * (1 + 1j)
+        for i in range(m):
+            for j in range(m):
+                gam[i, j, :] = np.fft.ifft(g[i, j, :])
+        gamp = gam.copy()
+        beta0 = 0.5 * gam[:, :, 0]
+        gamp[:, :, 0] = np.triu(beta0)
+        gamp[:, :, len(freq) :] = 0
+        gp = np.zeros([m, m, 2 * N]) * (1 + 1j)
+        for i in range(m):
+            for j in range(m):
+                gp[i, j, :] = np.fft.fft(gamp[i, j, :])
+        return gp
+
+    def _wilson_factorization(S, freq, fs, Niterations=n_iterations, tol=tol):
+        # Algorithm for the Wilson Factorization of the spectral matrix.
+        # From: https://github.com/ViniciusLima94/pyGC/blob/master/pygc/non_parametric.py
+        #
+        # Inputs:
+        # - Cross spectral density matrix: S (channels, channels, frequencies)
+        # - Frequency axis: freq (frequencies,)
+        # - Sampling frequency (Hz): fs
+        #
+        # Returns:
+        # - Left spectral factor: Snew (channels, channels, frequencies)
+        # - Transfer function: Hnew (channels, channels, frequencies)
+        # - Noise covariance: Znew (channels, channels)
+        m = S.shape[0]
+        N = freq.shape[0] - 1
+        Sarr = np.zeros([m, m, 2 * N]) * (1 + 1j)
+        f_ind = 0
+        for f in freq:
+            Sarr[:, :, f_ind] = S[:, :, f_ind]
+            if f_ind > 0:
+                Sarr[:, :, 2 * N - f_ind] = S[:, :, f_ind].T
+            f_ind += 1
+        gam = np.zeros([m, m, 2 * N])
+        for i in range(m):
+            for j in range(m):
+                gam[i, j, :] = (np.fft.ifft(Sarr[i, j, :])).real
+        gam0 = gam[:, :, 0]
+        h = np.linalg.cholesky(gam0).T
+        psi = np.ones([m, m, 2 * N]) * (1 + 1j)
+        for i in range(0, Sarr.shape[2]):
+            psi[:, :, i] = h
+        I = np.eye(m)
+        g = np.zeros([m, m, 2 * N]) * (1 + 1j)
+        for iteration in range(Niterations):
+            for i in range(Sarr.shape[2]):
+                g[:, :, i] = (
+                    np.matmul(
+                        np.matmul(np.linalg.inv(psi[:, :, i]), Sarr[:, :, i]),
+                        np.conj(np.linalg.inv(psi[:, :, i])).T,
+                    )
+                    + I
+                )
+            gp = _plus_operator(g, m, fs, freq)
+            psiold = psi.copy()
+            psierr = 0
+            for i in range(Sarr.shape[2]):
+                psi[:, :, i] = np.matmul(psi[:, :, i], gp[:, :, i])
+                psierr += (
+                    np.linalg.norm(psi[:, :, i] - psiold[:, :, i], 1) / Sarr.shape[2]
+                )
+            if psierr < tol:
+                break
+        Snew = np.zeros([m, m, N + 1]) * (1 + 1j)
+        for i in range(N + 1):
+            Snew[:, :, i] = np.matmul(psi[:, :, i], np.conj(psi[:, :, i]).T)
+        gamtmp = np.zeros([m, m, 2 * N]) * (1 + 1j)
+        for i in range(m):
+            for j in range(m):
+                gamtmp[i, j, :] = np.fft.ifft(psi[i, j, :]).real
+        A0 = gamtmp[:, :, 0]
+        A0inv = np.linalg.inv(A0)
+        Znew = np.matmul(A0, A0.T).real
+        Hnew = np.zeros([m, m, N + 1]) * (1 + 1j)
+        for i in range(N + 1):
+            Hnew[:, :, i] = np.matmul(psi[:, :, i], A0inv)
+        return Snew, Hnew, Znew
+
+    def _calc_pdc(S):
+        # S must be (channels, channels, frequencies)
+
+        # Calculate transfer function using Wilson's factorisation method
+        _, H, _ = _wilson_factorization(S, f, sampling_frequency)
+
+        # Calculate coefficient matrix
+        # Note, we need to reshape for compatibility with np.linalg.inv
+        H = np.moveaxis(H, -1, 0)
+        A = np.linalg.inv(H)
+        A = np.moveaxis(A, 0, -1)
+
+        # Calculate partial directed coherence
+        pdc = np.abs(A) / np.sqrt(np.sum(np.abs(A) ** 2, axis=0, keepdims=True))
+        return pdc.astype(np.float32)
+
+    # _calc_pdc works on 3D data, we flatten the input here
+    original_shape = cpsd.shape
+    flattened_cpsd = cpsd.reshape((-1, *original_shape[-3:]))
+
+    # Create keyword arguments to pass to the main function
+    kwargs = [{"S": S} for S in flattened_cpsd]
+
+    # Main calculation
+    if len(kwargs) == 1:
+        # We only have one array so we don't need to parallelise
+        # the calculation
+        _logger.info("Calculating PDC")
+        results = [_calc_pdc(**kwargs[0])]
+
+    elif n_jobs == 1:
+        # We have multiple arrays but we're running in serial
+        results = []
+        for i in trange(len(kwargs), desc="Calculating PDC"):
+            results.append(_calc_pdc(**kwargs[i]))
+
+    else:
+        # Calculate in parallel
+        _logger.info("Calculating PDC")
+        results = pqdm(
+            kwargs,
+            _calc_pdc,
+            n_jobs=n_jobs,
+            argument_type="kwargs",
+        )
+
+    # Put the results back into the original shape
+    pdc = np.array(results).reshape(original_shape)
+
+    if not keepdims:
+        # Remove any axes that are of length 1
+        pdc = np.squeeze(pdc)
+
+    return pdc
+
+
 def decompose_spectra(
     coherences,
     n_components,

--- a/osl_dynamics/analysis/spectral.py
+++ b/osl_dynamics/analysis/spectral.py
@@ -1345,8 +1345,7 @@ def _welch_spectrogram(
         (channels + 1) / 2, freq) if :code:`calc_cpsd=True`, otherwise
         it is (time, channels, freq).
     """
-    n_samples = data.shape[0]
-    n_channels = data.shape[1]
+    n_samples, n_channels = data.shape
 
     # Validation
     if window_length is None:
@@ -1522,11 +1521,10 @@ def _welch(
         Shape is (..., n_channels, n_channels, n_freq).
         Only returned is :code:`calc_coh=True`.
     """
-    if alpha is None:
-        alpha = np.ones([data.shape[0], 1], dtype=np.float32)
+    n_samples, n_channels = data.shape
 
-    n_samples = data.shape[0]
-    n_channels = data.shape[-1]
+    if alpha is None:
+        alpha = np.ones([n_samples, 1], dtype=np.float32)
     n_states = alpha.shape[-1]
 
     # Indices for the upper triangle of a channels by channels matrix
@@ -1658,8 +1656,7 @@ def _multitaper_spectrogram(
         (channels + 1) / 2, freq) if :code:`calc_cpsd=True`, otherwise
         it is (time, channels, freq).
     """
-    n_samples = data.shape[0]
-    n_channels = data.shape[1]
+    n_samples, n_channels = data.shape
 
     # Validation
     if window_length is None:
@@ -1853,11 +1850,10 @@ def _multitaper(
         Shape is (..., n_channels, n_channels, n_freq).
         Only returned is :code:`calc_coh=True`.
     """
+    n_samples, n_channels = data.shape
+
     if alpha is None:
         alpha = np.ones([n_samples, 1], dtype=np.float32)
-
-    n_samples = data.shape[0]
-    n_channels = data.shape[-1]
     n_states = alpha.shape[-1]
 
     # Indices for the upper triangle of a channels by channels matrix
@@ -2031,8 +2027,7 @@ def _window_mean(alpha, window, window_length, step_size, n_sub_windows):
     mean_window_alpha : np.ndarray
         Mean for each window.
     """
-    n_samples = alpha.shape[0]
-    n_modes = alpha.shape[1]
+    n_samples, n_modes = alpha.shape
 
     # Pad alphas
     alpha = np.pad(alpha, window_length // 2)[

--- a/osl_dynamics/analysis/spectral.py
+++ b/osl_dynamics/analysis/spectral.py
@@ -1582,7 +1582,7 @@ def _welch(
                 dtype=np.complex64,
             )
             cpsd[m, n] = p
-            cpsd[n, m] = p
+            cpsd[n, m] = np.conj(p)
 
             # Unpack PSDs
             psd.append(cpsd[range(n_channels), range(n_channels)].real)
@@ -1915,7 +1915,7 @@ def _multitaper(
                 dtype=np.complex64,
             )
             cpsd[m, n] = p
-            cpsd[n, m] = p
+            cpsd[n, m] = np.conj(p)
 
             # Unpack PSDs
             psd.append(cpsd[range(n_channels), range(n_channels)].real)
@@ -1929,7 +1929,7 @@ def _multitaper(
                 dtype=np.complex64,
             )
             cpsd[m, n] = p
-            cpsd[n, m] = p
+            cpsd[n, m] = np.conj(p)
             psd.append(cpsd)
 
         else:

--- a/osl_dynamics/analysis/spectral.py
+++ b/osl_dynamics/analysis/spectral.py
@@ -12,7 +12,6 @@ from tqdm.auto import trange
 
 from osl_dynamics import array_ops
 from osl_dynamics.analysis import regression
-from osl_dynamics.inference import modes
 from osl_dynamics.utils.misc import nextpow2
 
 _logger = logging.getLogger("osl-dynamics")
@@ -877,7 +876,6 @@ def partial_coherence_spectra(cpsd, keepdims=False):
 
     where :math:`x,y` are different channels and :math:`P^{-1}(f)`
     is the inverse of the cross spectral density matrix.
-
 
     Parameters
     ----------

--- a/osl_dynamics/analysis/spectral.py
+++ b/osl_dynamics/analysis/spectral.py
@@ -903,7 +903,7 @@ def partial_coherence_spectra(cpsd, keepdims=False):
     return coherence_spectra(icpsd, keepdims=keepdims)
 
 
-def partial_directed_coherence(
+def partial_directed_coherence_spectra(
     f,
     cpsd,
     sampling_frequency,
@@ -912,7 +912,16 @@ def partial_directed_coherence(
     keepdims=False,
     n_jobs=1,
 ):
-    """Calculate partial directed coherence from the cross power spectra.
+    r"""Calculate partial directed coherence from cross power spectra.
+
+    We calculate the partial directed coherence as:
+
+    .. math::
+        PDC_{ij}(f) = \frac{|A_{ij}(f)|}{\sqrt{\sum_m |A_{mj}(f)|^2}}
+
+    where :math:`i,j` are different channels and :math:`A(f) = H^{-1}(f)`
+    is the inverse of the transfer function, which calculated by factorizing
+    the cross spectral density matrix.
 
     Parameters
     ----------
@@ -940,112 +949,21 @@ def partial_directed_coherence(
         Shape is (..., n_channels, n_channels, n_freq).
     """
 
-    def _plus_operator(g, m, fs, freq):
-        # Helper function for wilson_factorization
-        N = freq.shape[0] - 1
-        gam = np.zeros([m, m, 2 * N]) * (1 + 1j)
-        for i in range(m):
-            for j in range(m):
-                gam[i, j, :] = np.fft.ifft(g[i, j, :])
-        gamp = gam.copy()
-        beta0 = 0.5 * gam[:, :, 0]
-        gamp[:, :, 0] = np.triu(beta0)
-        gamp[:, :, len(freq) :] = 0
-        gp = np.zeros([m, m, 2 * N]) * (1 + 1j)
-        for i in range(m):
-            for j in range(m):
-                gp[i, j, :] = np.fft.fft(gamp[i, j, :])
-        return gp
-
-    def _wilson_factorization(S, freq, fs, Niterations=n_iterations, tol=tol):
-        # Algorithm for the Wilson Factorization of the spectral matrix.
-        # From: https://github.com/ViniciusLima94/pyGC/blob/master/pygc/non_parametric.py
-        #
-        # Inputs:
-        # - Cross spectral density matrix: S (channels, channels, frequencies)
-        # - Frequency axis: freq (frequencies,)
-        # - Sampling frequency (Hz): fs
-        #
-        # Returns:
-        # - Left spectral factor: Snew (channels, channels, frequencies)
-        # - Transfer function: Hnew (channels, channels, frequencies)
-        # - Noise covariance: Znew (channels, channels)
-        m = S.shape[0]
-        N = freq.shape[0] - 1
-        Sarr = np.zeros([m, m, 2 * N]) * (1 + 1j)
-        f_ind = 0
-        for f in freq:
-            Sarr[:, :, f_ind] = S[:, :, f_ind]
-            if f_ind > 0:
-                Sarr[:, :, 2 * N - f_ind] = S[:, :, f_ind].T
-            f_ind += 1
-        gam = np.zeros([m, m, 2 * N])
-        for i in range(m):
-            for j in range(m):
-                gam[i, j, :] = (np.fft.ifft(Sarr[i, j, :])).real
-        gam0 = gam[:, :, 0]
-        h = np.linalg.cholesky(gam0).T
-        psi = np.ones([m, m, 2 * N]) * (1 + 1j)
-        for i in range(0, Sarr.shape[2]):
-            psi[:, :, i] = h
-        I = np.eye(m)
-        g = np.zeros([m, m, 2 * N]) * (1 + 1j)
-        for iteration in range(Niterations):
-            for i in range(Sarr.shape[2]):
-                g[:, :, i] = (
-                    np.matmul(
-                        np.matmul(np.linalg.inv(psi[:, :, i]), Sarr[:, :, i]),
-                        np.conj(np.linalg.inv(psi[:, :, i])).T,
-                    )
-                    + I
-                )
-            gp = _plus_operator(g, m, fs, freq)
-            psiold = psi.copy()
-            psierr = 0
-            for i in range(Sarr.shape[2]):
-                psi[:, :, i] = np.matmul(psi[:, :, i], gp[:, :, i])
-                psierr += (
-                    np.linalg.norm(psi[:, :, i] - psiold[:, :, i], 1) / Sarr.shape[2]
-                )
-            if psierr < tol:
-                break
-        Snew = np.zeros([m, m, N + 1]) * (1 + 1j)
-        for i in range(N + 1):
-            Snew[:, :, i] = np.matmul(psi[:, :, i], np.conj(psi[:, :, i]).T)
-        gamtmp = np.zeros([m, m, 2 * N]) * (1 + 1j)
-        for i in range(m):
-            for j in range(m):
-                gamtmp[i, j, :] = np.fft.ifft(psi[i, j, :]).real
-        A0 = gamtmp[:, :, 0]
-        A0inv = np.linalg.inv(A0)
-        Znew = np.matmul(A0, A0.T).real
-        Hnew = np.zeros([m, m, N + 1]) * (1 + 1j)
-        for i in range(N + 1):
-            Hnew[:, :, i] = np.matmul(psi[:, :, i], A0inv)
-        return Snew, Hnew, Znew
-
-    def _calc_pdc(S):
-        # S must be (channels, channels, frequencies)
-
-        # Calculate transfer function using Wilson's factorisation method
-        _, H, _ = _wilson_factorization(S, f, sampling_frequency)
-
-        # Calculate coefficient matrix
-        # Note, we need to reshape for compatibility with np.linalg.inv
-        H = np.moveaxis(H, -1, 0)
-        A = np.linalg.inv(H)
-        A = np.moveaxis(A, 0, -1)
-
-        # Calculate partial directed coherence
-        pdc = np.abs(A) / np.sqrt(np.sum(np.abs(A) ** 2, axis=0, keepdims=True))
-        return pdc.astype(np.float32)
-
     # _calc_pdc works on 3D data, we flatten the input here
     original_shape = cpsd.shape
     flattened_cpsd = cpsd.reshape((-1, *original_shape[-3:]))
 
-    # Create keyword arguments to pass to the main function
-    kwargs = [{"S": S} for S in flattened_cpsd]
+    # Create keyword arguments to pass to _calc_pdc
+    kwargs = [
+        {
+            "f": f,
+            "cpsd": S,
+            "sampling_frequency": sampling_frequency,
+            "n_iterations": n_iterations,
+            "tol": tol,
+        }
+        for S in flattened_cpsd
+    ]
 
     # Main calculation
     if len(kwargs) == 1:
@@ -2122,3 +2040,123 @@ def _window_mean(alpha, window, window_length, step_size, n_sub_windows):
         mean_window_alpha[i] = np.mean(a_sub_window, axis=0)
 
     return mean_window_alpha
+
+
+def _calc_pdc(f, cpsd, sampling_frequency, n_iterations=100, tol=1e-10):
+    """Calculate partial directed coherence from a single cross spectrum.
+
+    Parameters
+    ----------
+    f : np.ndarray
+        Frequency axis. Shape must be (n_freq,).
+    cpsd : np.ndarray
+        Cross spectral density matrix.
+        Shape must be (n_channels, n_channels, n_freq).
+    sampling_frequency : float
+        Sampling frequency in Hz.
+    n_iterations : int, optional
+        Number of iterations for Wilson factorization.
+    tol : float, optional
+        Tolerance for Wilson factorization.
+
+    Returns
+    -------
+    pdc : np.ndarray
+        Partial directed coherence.
+        Shape is (n_channels, n_channels, n_freq).
+    """
+
+    def _plus_operator(g, m, fs, freq):
+        # Helper function for wilson_factorization
+        N = freq.shape[0] - 1
+        gam = np.zeros([m, m, 2 * N]) * (1 + 1j)
+        for i in range(m):
+            for j in range(m):
+                gam[i, j, :] = np.fft.ifft(g[i, j, :])
+        gamp = gam.copy()
+        beta0 = 0.5 * gam[:, :, 0]
+        gamp[:, :, 0] = np.triu(beta0)
+        gamp[:, :, len(freq) :] = 0
+        gp = np.zeros([m, m, 2 * N]) * (1 + 1j)
+        for i in range(m):
+            for j in range(m):
+                gp[i, j, :] = np.fft.fft(gamp[i, j, :])
+        return gp
+
+    def _wilson_factorization(
+        S, freq=f, fs=sampling_frequency, Niterations=n_iterations, tol=tol
+    ):
+        # Algorithm for the Wilson Factorization of the spectral matrix.
+        # From: https://github.com/ViniciusLima94/pyGC/blob/master/pygc/non_parametric.py
+        #
+        # Returns:
+        # - Left spectral factor: Snew (channels, channels, frequencies)
+        # - Transfer function: Hnew (channels, channels, frequencies)
+        # - Noise covariance: Znew (channels, channels)
+        m = S.shape[0]
+        N = freq.shape[0] - 1
+        Sarr = np.zeros([m, m, 2 * N]) * (1 + 1j)
+        f_ind = 0
+        for f in freq:
+            Sarr[:, :, f_ind] = S[:, :, f_ind]
+            if f_ind > 0:
+                Sarr[:, :, 2 * N - f_ind] = S[:, :, f_ind].T
+            f_ind += 1
+        gam = np.zeros([m, m, 2 * N])
+        for i in range(m):
+            for j in range(m):
+                gam[i, j, :] = (np.fft.ifft(Sarr[i, j, :])).real
+        gam0 = gam[:, :, 0]
+        h = np.linalg.cholesky(gam0).T
+        psi = np.ones([m, m, 2 * N]) * (1 + 1j)
+        for i in range(0, Sarr.shape[2]):
+            psi[:, :, i] = h
+        I = np.eye(m)
+        g = np.zeros([m, m, 2 * N]) * (1 + 1j)
+        for iteration in range(Niterations):
+            for i in range(Sarr.shape[2]):
+                g[:, :, i] = (
+                    np.matmul(
+                        np.matmul(np.linalg.inv(psi[:, :, i]), Sarr[:, :, i]),
+                        np.conj(np.linalg.inv(psi[:, :, i])).T,
+                    )
+                    + I
+                )
+            gp = _plus_operator(g, m, fs, freq)
+            psiold = psi.copy()
+            psierr = 0
+            for i in range(Sarr.shape[2]):
+                psi[:, :, i] = np.matmul(psi[:, :, i], gp[:, :, i])
+                psierr += (
+                    np.linalg.norm(psi[:, :, i] - psiold[:, :, i], 1) / Sarr.shape[2]
+                )
+            if psierr < tol:
+                break
+        Snew = np.zeros([m, m, N + 1]) * (1 + 1j)
+        for i in range(N + 1):
+            Snew[:, :, i] = np.matmul(psi[:, :, i], np.conj(psi[:, :, i]).T)
+        gamtmp = np.zeros([m, m, 2 * N]) * (1 + 1j)
+        for i in range(m):
+            for j in range(m):
+                gamtmp[i, j, :] = np.fft.ifft(psi[i, j, :]).real
+        A0 = gamtmp[:, :, 0]
+        A0inv = np.linalg.inv(A0)
+        Znew = np.matmul(A0, A0.T).real
+        Hnew = np.zeros([m, m, N + 1]) * (1 + 1j)
+        for i in range(N + 1):
+            Hnew[:, :, i] = np.matmul(psi[:, :, i], A0inv)
+        return Snew, Hnew, Znew
+
+    # Calculate transfer function using Wilson's factorisation method
+    _, H, _ = _wilson_factorization(cpsd)
+
+    # Calculate coefficient matrix
+    # Note, we need to reshape for compatibility with np.linalg.inv
+    H = np.moveaxis(H, -1, 0)
+    A = np.linalg.inv(H)
+    A = np.moveaxis(A, 0, -1)
+
+    # Calculate partial directed coherence
+    pdc = np.abs(A) / np.sqrt(np.sum(np.abs(A) ** 2, axis=0, keepdims=True))
+
+    return pdc.astype(np.float32)


### PR DESCRIPTION
Changes:
- Improved functions for calculating post-hoc spectral properties.
- Added functions to calculate partial coherence and partial directed coherence.
- Added definitions to docstrings.
- **Benchmarked multitaper calculations against the Matlab HMM-MAR toolbox.**

Generated multitaper spectra using the HMM-MAR with:
```
load('data/X.mat')  % contains fields for x and a

options = struct('Fs',250);
options.fpass = [1 45];
options.tapers = [4 7];
options.p = 0;
options.win = 500;
options.to_do = [1 1]; % do coh and pdc
options.order = 0;

mt = hmmspectramt(x,[size(a,1)],a,options);
save('data/mt.mat', 'mt')
```

Tested against osl-dynamics with:
```
import numpy as np
from scipy import io
from osl_dynamics.analysis import spectral
from osl_dynamics.utils import plotting

state = 1
chan1 = 11
chan2 = 20

mat = io.loadmat("data/mt.mat", simplify_cells=True)
mat = mat["mt"]["state"][state]
mat_f = mat["f"]
mat_cpsd = np.moveaxis(mat["psd"], 0, -1)
mat_coh = np.moveaxis(mat["coh"], 0, -1)
mat_pcoh = np.moveaxis(mat["pcoh"], 0, -1)
mat_pdc = np.moveaxis(mat["pdc"], 0, -1)

x = np.load("data/x.npy")
a = np.load("data/a.npy")

f, cpsd = spectral.multitaper_spectra(
    data=x,
    alpha=a,
    sampling_frequency=250,
    frequency_range=[1, 45],
    calc_cpsd=True,
)
cpsd = cpsd[state]

# Note, we use a different normalisation compared to HMM-MAR
# which is why we have the factor of 2 difference
plotting.plot_line(
    [f, mat_f, f, mat_f],
    [cpsd[chan1, chan2].real, 2 * mat_cpsd[chan1, chan2].real,
     cpsd[chan1, chan2].imag, 2 * mat_cpsd[chan1, chan2].imag],
    labels=["Python - Real", "Matlab - Real", "Python - Imag", "Matlab - Imag"],
    x_label="Frequency (Hz)",
    y_label="PSD (a.u.)",
    filename="plots/psd.png",
)

coh = spectral.coherence_spectra(cpsd)

plotting.plot_line(
    [f, mat_f],
    [coh[chan1, chan2], mat_coh[chan1, chan2]],
    labels=["Python", "Matlab"],
    x_label="Frequency (Hz)",
    y_label="Coherence",
    filename="plots/coh.png",
)

pcoh = spectral.partial_coherence_spectra(cpsd)

plotting.plot_line(
    [f, mat_f],
    [pcoh[chan1, chan2], mat_pcoh[chan1, chan2]],
    labels=["Python", "Matlab"],
    x_label="Frequency (Hz)",
    y_label="Coherence",
    filename="plots/pcoh.png",
) 

pdc = spectral.partial_directed_coherence_spectra(
    f=f,
    cpsd=cpsd,
    sampling_frequency=250,
)

plotting.plot_line(
    [f, mat_f],
    [pdc[chan1, chan2], mat_pdc[chan1, chan2]],
    labels=["Python", "Matlab"],
    x_label="Frequency (Hz)",
    y_label="PDC",
    filename="plots/pdc.png",
)
```