### PR TITLE
Feat: Save model with checkpoints.

### DIFF
--- a/osl_dynamics/inference/callbacks.py
+++ b/osl_dynamics/inference/callbacks.py
@@ -3,9 +3,9 @@
 """
 
 import numpy as np
+import tensorflow as tf
 from tensorflow import tanh
 from tensorflow.keras import callbacks
-import tensorflow as tf
 
 from osl_dynamics import inference
 

--- a/osl_dynamics/inference/callbacks.py
+++ b/osl_dynamics/inference/callbacks.py
@@ -5,6 +5,7 @@
 import numpy as np
 from tensorflow import tanh
 from tensorflow.keras import callbacks
+import tensorflow as tf
 
 from osl_dynamics import inference
 
@@ -267,3 +268,28 @@ class SaveBestCallback(callbacks.ModelCheckpoint):
             validation is performed.
         """
         self.model.load_weights(self.filepath)
+
+
+class CheckpointCallback(callbacks.Callback):
+    """Callback to create checkpoints during training.
+
+    Parameters
+    ----------
+    save_freq : int
+        Frequency (in epochs) at which to save the model.
+    """
+
+    def __init__(self, save_freq, checkpoint_dir):
+        super().__init__()
+        self.save_freq = save_freq
+        self.checkpoint = None
+        self.checkpoint_dir = checkpoint_dir
+        self.checkpoint_prefix = f"{checkpoint_dir}/ckpt"
+
+    def on_epoch_end(self, epoch, logs=None):
+        if self.checkpoint is None:
+            self.checkpoint = tf.train.Checkpoint(
+                model=self.model, optimizer=self.model.optimizer
+            )
+        if (epoch + 1) % self.save_freq == 0:
+            self.checkpoint.save(file_prefix=self.checkpoint_prefix)

--- a/osl_dynamics/models/inf_mod_base.py
+++ b/osl_dynamics/models/inf_mod_base.py
@@ -112,7 +112,7 @@ class VariationalInferenceModelBase(ModelBase):
             decay_start_epoch = self.config.n_kl_annealing_epochs
         else:
             decay_start_epoch = 0
-        learning_rate = self.config.learning_rate
+        learning_rate = self.model.optimizer.learning_rate.numpy()
 
         def lr_scheduler(epoch, lr):
             if epoch < decay_start_epoch:

--- a/osl_dynamics/models/mod_base.py
+++ b/osl_dynamics/models/mod_base.py
@@ -169,6 +169,7 @@ class ModelBase:
         use_tqdm=False,
         tqdm_class=None,
         save_best_after=None,
+        checkpoint_freq=None,
         save_filepath=None,
         **kwargs,
     ):
@@ -188,6 +189,8 @@ class ModelBase:
         save_best_after : int, optional
             Epoch number after which we should save the best model. The best
             model is that which achieves the lowest loss.
+        checkpoint_freq : int, optional
+            Frequency (in epochs) at which to create checkpoints.
         save_filepath : str, optional
             Path to save the best model to.
         additional_callbacks : list, optional
@@ -237,6 +240,16 @@ class ModelBase:
                 filepath=save_filepath,
             )
             additional_callbacks.append(save_best_callback)
+
+        if checkpoint_freq is not None:
+            if save_filepath is None:
+                save_filepath = f"tmp"
+            self.save_config(save_filepath)
+            checkpoint_callback = callbacks.CheckpointCallback(
+                save_freq=checkpoint_freq,
+                checkpoint_dir=f"{save_filepath}/checkpoints",
+            )
+            additional_callbacks.append(checkpoint_callback)
 
         # Update arguments/keyword arguments to pass to the fit method
         args, kwargs = replace_argument(
@@ -604,13 +617,15 @@ class ModelBase:
         return config_dict, version
 
     @classmethod
-    def load(cls, dirname, single_gpu=True):
+    def load(cls, dirname, from_checkpoint=True, single_gpu=True):
         """Load model from :code:`dirname`.
 
         Parameters
         ----------
         dirname : str
             Directory where :code:`config.yml` and weights are stored.
+        from_checkpoint : bool, optional
+            Should we load the model from a checkpoint?
         single_gpu : bool, optional
             Should we compile the model on a single GPU?
 
@@ -641,8 +656,16 @@ class ModelBase:
         model = cls(config)
         model.osld_version = version
 
-        # Restore weights
-        model.load_weights(f"{dirname}/weights").expect_partial()
+        # Restore model
+        if from_checkpoint:
+            checkpoint = tf.train.Checkpoint(
+                model=model.model, optimizer=model.model.optimizer
+            )
+            checkpoint.restore(
+                tf.train.latest_checkpoint(f"{dirname}/checkpoints")
+            ).expect_partial()
+        else:
+            model.load_weights(f"{dirname}/weights").expect_partial()
 
         return model
 

--- a/osl_dynamics/models/mod_base.py
+++ b/osl_dynamics/models/mod_base.py
@@ -664,6 +664,10 @@ class ModelBase:
             checkpoint.restore(
                 tf.train.latest_checkpoint(f"{dirname}/checkpoints")
             ).expect_partial()
+
+            # For HMM, also need to load the trans prob
+            if config["model_name"] == "HMM":
+                model.trans_prob = np.load(f"{dirname}/trans_prob.npy")
         else:
             model.load_weights(f"{dirname}/weights").expect_partial()
 


### PR DESCRIPTION
Added the option to save checkpoints during training. This includes both model and optimizer weights to allow further training.

Create checkpoints during training with:
```
model.fit(data, checkpoint_freq=5, save_filepath=model_dir)
```
and load model from the latest checkpoint with:
```
model = Model.load(model_dir, from_checkpoint=True)
```