### PR TITLE
Validation Split

### DIFF
--- a/osl_dynamics/data/base.py
+++ b/osl_dynamics/data/base.py
@@ -1387,17 +1387,19 @@ class Data:
             X_train = []
             X_val = []
             for i in range(self.n_sessions):
+                if i not in self.keep:
+                    continue
+
                 # Randomly pick sequences
-                val_sequences = np.random.choice(
+                val_indx = np.random.choice(
                     n_sequences[i], size=n_val_sequences[i], replace=False
                 )
-                mask = np.zeros(n_sequences[i], dtype=bool)
-                mask[val_sequences] = True
+                train_indx = np.setdiff1d(np.arange(n_sequences[i]), val_indx)
 
                 # Split data
                 x = X[i].reshape(-1, sequence_length, self.n_channels)
-                x_train = x[~mask].reshape(-1, self.n_channels)
-                x_val = x[mask].reshape(-1, self.n_channels)
+                x_train = x[train_indx].reshape(-1, self.n_channels)
+                x_val = x[val_indx].reshape(-1, self.n_channels)
                 X_train.append(x_train)
                 X_val.append(x_val)
 
@@ -1509,16 +1511,15 @@ class Data:
 
             if validation_split is not None:
                 # Randomly pick sequences
-                val_sequences = np.random.choice(
+                val_indx = np.random.choice(
                     n_sequences[i], size=n_val_sequences[i], replace=False
                 )
-                mask = np.zeros(n_sequences[i], dtype=bool)
-                mask[val_sequences] = True
+                train_indx = np.setdiff1d(np.arange(n_sequences[i]), val_indx)
 
                 # Split data
                 x = x.reshape(-1, sequence_length, self.n_channels)
-                x_train = x[~mask].reshape(-1, self.n_channels)
-                x_val = x[mask].reshape(-1, self.n_channels)
+                x_train = x[train_indx].reshape(-1, self.n_channels)
+                x_val = x[val_indx].reshape(-1, self.n_channels)
 
                 # Save datasets
                 X_train = self._create_data_dict(i, x_train)

--- a/osl_dynamics/data/base.py
+++ b/osl_dynamics/data/base.py
@@ -1338,8 +1338,6 @@ class Data:
                         self.batch_size, drop_remainder=drop_last_batch
                     )
 
-                _logger.info(f"{len(full_dataset)} batches in dataset")
-
                 import tensorflow as tf  # moved here to avoid slow imports
 
                 return full_dataset.prefetch(tf.data.AUTOTUNE)
@@ -1358,8 +1356,6 @@ class Data:
                     if shuffle:
                         # Shuffle batches
                         ds = ds.shuffle(self.buffer_size)
-
-                    _logger.info(f"Session {i}: {len(ds)} batches in dataset")
 
                     import tensorflow as tf  # moved here to avoid slow imports
 
@@ -1404,13 +1400,7 @@ class Data:
                 X_train.append(x_train)
                 X_val.append(x_val)
 
-            _logger.info("Training dataset")
-            training_dataset = _create_dataset(X_train)
-
-            _logger.info("Validation dataset")
-            validation_dataset = _create_dataset(X_val)
-
-            return training_dataset, validation_dataset
+            return _create_dataset(X_train), _create_dataset(X_val)
 
         else:
             return _create_dataset(X)


### PR DESCRIPTION
Closes https://github.com/OHBA-analysis/osl-dynamics/issues/277.

Changes:
- Updated implementation of validation split in the Data object.

Note:
- We no longer need `keras.utils.split_dataset`, which means we are compatible with TensorFlow <2.11.
- If `Data.tfrecord_dataset` is called multiple times and we rewrite the TFRecord files, we will get a new random split for each session each time.