### PR TITLE
Add validation for batching process

### DIFF
--- a/osl_dynamics/data/tf.py
+++ b/osl_dynamics/data/tf.py
@@ -28,9 +28,16 @@ def get_n_sequences(arr, sequence_length, step_size=None):
     n : int
         Number of sequences.
     """
-    step_size = step_size or sequence_length
-    n_samples = (arr.shape[0] // sequence_length) * sequence_length
-    return n_samples // step_size
+    n_samples = arr.shape[0]
+
+    # Number of non-overlapping sequences
+    n_sequences = n_samples // sequence_length
+
+    if step_size is not None:
+        # Number of overlapping sequences
+        n_sequences += (n_samples - step_size) // sequence_length
+
+    return n_sequences
 
 
 def concatenate_datasets(datasets):


### PR DESCRIPTION
This pull request adds a functionality to validate batching process based on a user-defined batch size and sequence length. Currently, `batch_size` and `sequence_length` that do not match with the number of data samples can cause errors when a user is running a model. This PR prevents this issue and handles the error better.

The `_validate_batching()` function has been tested on different use cases (i.e., with different batch sizes and sequence lengths) and also on the real data. The number of batches calculated here matches with `dtf.get_n_batches(training_dataset)`.