### PR TITLE
Feat: Repeat dataset when steps_per_epoch is passed to model.fit().

### DIFF
--- a/osl_dynamics/data/base.py
+++ b/osl_dynamics/data/base.py
@@ -1390,6 +1390,7 @@ class Data:
         concatenate=True,
         step_size=None,
         drop_last_batch=False,
+        repeat_count=1,
     ):
         """Create a Tensorflow Dataset for training or evaluation.
 
@@ -1411,6 +1412,8 @@ class Data:
             Default is no overlap.
         drop_last_batch : bool, optional
             Should we drop the last batch if it is smaller than the batch size?
+        repeat_count : int, optional
+            Number of times to repeat the dataset. Default is once.
 
         Returns
         -------
@@ -1434,7 +1437,7 @@ class Data:
 
         n_sequences = self.count_sequences(self.sequence_length)
 
-        def _create_dataset(X):
+        def _create_dataset(X, shuffle=shuffle, repeat_count=repeat_count):
             # X is a list of np.ndarray
 
             # Create datasets for each array
@@ -1475,6 +1478,9 @@ class Data:
                         self.batch_size, drop_remainder=drop_last_batch
                     )
 
+                # Repeat the dataset
+                full_dataset = full_dataset.repeat(repeat_count)
+
                 import tensorflow as tf  # moved here to avoid slow imports
 
                 return full_dataset.prefetch(tf.data.AUTOTUNE)
@@ -1493,6 +1499,9 @@ class Data:
                     if shuffle:
                         # Shuffle batches
                         ds = ds.shuffle(self.buffer_size)
+
+                    # Repeat the dataset
+                    ds = ds.repeat(repeat_count)
 
                     import tensorflow as tf  # moved here to avoid slow imports
 
@@ -1539,7 +1548,9 @@ class Data:
                 X_train.append(x_train)
                 X_val.append(x_val)
 
-            return _create_dataset(X_train), _create_dataset(X_val)
+            return _create_dataset(X_train), _create_dataset(
+                X_val, shuffle=False, repeat_count=1
+            )
 
         else:
             return _create_dataset(X)
@@ -1728,6 +1739,7 @@ class Data:
         concatenate=True,
         step_size=None,
         drop_last_batch=False,
+        repeat_count=1,
         tfrecord_dir=None,
         overwrite=False,
     ):
@@ -1750,6 +1762,8 @@ class Data:
             Default is no overlap.
         drop_last_batch : bool, optional
             Should we drop the last batch if it is smaller than the batch size?
+        repeat_count : int, optional
+            Number of times to repeat the dataset. Default is once.
         tfrecord_dir : str, optional
             Directory to save the TFRecord datasets. If :code:`None`, then
             :code:`Data.store_dir` is used.
@@ -1787,6 +1801,7 @@ class Data:
             shuffle=shuffle,
             concatenate=concatenate,
             drop_last_batch=drop_last_batch,
+            repeat_count=repeat_count,
             buffer_size=self.buffer_size,
             keep=self.keep,
         )

--- a/osl_dynamics/models/mod_base.py
+++ b/osl_dynamics/models/mod_base.py
@@ -211,10 +211,20 @@ class ModelBase:
         history : history
             The training history.
         """
+        # If step_per_epoch is passed, repeat the dataset indefinitely
+        steps_per_epoch = get_argument(self.model.fit, "steps_per_epoch", args, kwargs)
+        repeat_count = 1 if steps_per_epoch is None else -1
+
         # If a osl_dynamics.data.Data object has been passed for the x
         # arguments, replace it with a tensorflow dataset
         x = get_argument(self.model.fit, "x", args, kwargs)
-        x = self.make_dataset(x, shuffle=True, concatenate=True, drop_last_batch=True)
+        x = self.make_dataset(
+            x,
+            shuffle=True,
+            concatenate=True,
+            drop_last_batch=True,
+            repeat_count=repeat_count,
+        )
         args, kwargs = replace_argument(self.model.fit, "x", x, args, kwargs)
 
         # Use the number of epochs in the config if it has not been passed
@@ -311,6 +321,7 @@ class ModelBase:
         concatenate=False,
         step_size=None,
         drop_last_batch=False,
+        repeat_count=1,
     ):
         """Converts a Data object into a TensorFlow Dataset.
 
@@ -328,6 +339,8 @@ class ModelBase:
             Default is no overlap.
         drop_last_batch : bool, optional
             Should we drop the last batch if it is smaller than the batch size?
+        repeat_count : int, optional
+            Number of times to repeat the dataset.
 
         Returns
         -------
@@ -361,6 +374,7 @@ class ModelBase:
                     concatenate=concatenate,
                     step_size=step_size,
                     drop_last_batch=drop_last_batch,
+                    repeat_count=repeat_count,
                     overwrite=True,
                 )
             else:
@@ -371,6 +385,7 @@ class ModelBase:
                     concatenate=concatenate,
                     step_size=step_size,
                     drop_last_batch=drop_last_batch,
+                    repeat_count=repeat_count,
                 )
 
         elif isinstance(inputs, Dataset) and not concatenate:


### PR DESCRIPTION
Added feature to repeat datasets.

This allows the users to pass `steps_per_epoch` to `model.fit()`, which is useful for early stopping with the `tf.keras.callbacks.ModelCheckpoint` callback.

This PR also prevents shuffling and repeating the validation dataset, which is the preferred behaviour when `validation_steps` is passed to `model.fit()` so that the same validation set is used for different epochs.