### PR TITLE
Add temperature annealing callback for the Gumbel-softmax distribution

### DIFF
--- a/osl_dynamics/inference/layers.py
+++ b/osl_dynamics/inference/layers.py
@@ -374,7 +374,7 @@ class SampleGumbelSoftmaxDistributionLayer(layers.Layer):
 
     def __init__(self, temperature, **kwargs):
         super().__init__(**kwargs)
-        self.temperature = temperature
+        self.temperature = tf.Variable(temperature, trainable=False, dtype=tf.float32)
 
     def call(self, inputs, **kwargs):
         """This method accepts logits and outputs samples."""


### PR DESCRIPTION
This pull request introduces a callback for annealing the temperature in a Gumbel-Softmax distribution (`GumbelSoftmaxAnnealingCallback`). The current implementation supports linear annealing, but we can expand it to include other annealing strategies in the future.

The changes are backwards compatible and tested with model training scripts. This enhancement aims to improve the flexibility of temperature scheduling in `SampleGumbelSoftmaxDistributionLayer`.