### PR TITLE
Fix / Enhance: Implement sequence-based computation for the dual estimation

### DIFF
--- a/osl_dynamics/analysis/modes.py
+++ b/osl_dynamics/analysis/modes.py
@@ -797,7 +797,8 @@ def hmm_dual_estimation(data, alpha, zero_mean=False, eps=1e-5, n_jobs=1):
     eps : float, optional
         Small value to add to the diagonal of each state covariance.
     n_jobs : int, optional
-        Number of jobs to run in parallel.
+        Number of jobs to run in parallel. If set as None, the function
+        will run sequentially.
 
     Returns
     -------


### PR DESCRIPTION
### Fix Memory Overflow in Dual Estimation of Covariances

Multiple users have reported a memory overflow issue when dual-estimating covariances from large datasets. The issue specifically occurs during covariance computation from the demeaned data matrix:
```
diff = x - session_means[state]
```

#### Solution

This PR implements a sequentialised approach to dual-estimation. Instead of computing the outer product of the entire data matrix at once, we segment the data time series into smaller sequences, reducing memory consumption during the calculation.

#### Impact

* This change affects only the HMM model.
* I validated that the sequentialised method produces identical results ot the original implementation.
* Tested on a simulated dataset of similar size to those reported by the users, the code no longer encounters memory overload errors.