### PR TITLE
Fix: Use same random initialisation methods

### DIFF
--- a/osl_dynamics/models/inf_mod_base.py
+++ b/osl_dynamics/models/inf_mod_base.py
@@ -206,7 +206,6 @@ class VariationalInferenceModelBase(ModelBase):
             training_data,
             shuffle=True,
             concatenate=True,
-            drop_last_batch=True,
         )
 
         # Calculate the number of batches to use
@@ -302,10 +301,8 @@ class VariationalInferenceModelBase(ModelBase):
             n_kl_annealing_epochs or original_n_kl_annealing_epochs
         )
 
-        # Make a list of tensorflow Datasets if the data
-        training_data = self.make_dataset(
-            training_data, shuffle=True, drop_last_batch=True
-        )
+        # Make a list of TensorFlow Datasets
+        training_data = self.make_dataset(training_data, shuffle=True)
 
         if not isinstance(training_data, list):
             raise ValueError(
@@ -418,7 +415,9 @@ class VariationalInferenceModelBase(ModelBase):
 
         # Make a TensorFlow Dataset
         training_dataset = self.make_dataset(
-            training_data, shuffle=True, concatenate=True, drop_last_batch=True
+            training_data,
+            shuffle=True,
+            concatenate=True,
         )
 
         # Calculate the number of batches to use
@@ -1261,7 +1260,9 @@ class MarkovStateInferenceModelBase(ModelBase):
 
         # Make a TensorFlow Dataset
         training_dataset = self.make_dataset(
-            training_data, shuffle=True, concatenate=True, drop_last_batch=True
+            training_data,
+            shuffle=True,
+            concatenate=True,
         )
 
         # Calculate the number of batches to use
@@ -1344,7 +1345,9 @@ class MarkovStateInferenceModelBase(ModelBase):
 
         # Make a TensorFlow Dataset
         training_dataset = self.make_dataset(
-            training_data, shuffle=True, concatenate=True, drop_last_batch=True
+            training_data,
+            shuffle=True,
+            concatenate=True,
         )
 
         # Calculate the number of batches to use


### PR DESCRIPTION
Currently, when building TensorFlow datasets for random initialisations or model fitting, we inconsistently handle the last data batch:

- For HMM initialisation/training and DyNeMo training, we set `drop_last_batch=False`.
- However, for DyNeMo initialisation (and more generally initialisations of `VariationalInferenceModel` or `MarkovStateInferenceModel`), we set `drop_last_batch=True`.

This pull request unifies the handling by setting `drop_last_batch=False` for all random initialisation methods. This ensures consistency across all model initialisation strategies.