### PR TITLE
Enhance: TensorBoard callbacks

### DIFF
--- a/osl_dynamics/inference/callbacks.py
+++ b/osl_dynamics/inference/callbacks.py
@@ -423,7 +423,10 @@ class GradientMonitoringCallback(tf.keras.callbacks.Callback):
         Indices of the losses in the model output.
     log_dir : str, optional
         Path to a directory where gradient logs will be saved.
-        Defaults to None, in which case the logs will be written to a current directory.
+        Defaults to None, in which case the logs will be written to the current directory.
+    log_as_dense : bool, optional
+        Whether to log gradients as dense tensors or not. Defaults to True.
+        If False, only non-zero gradients will be logged (if the gradient is sparse).
     print_stats : bool, optional
         Wheter to print the summary statistics (mean, std, min, max, L2 norm) for each variable.
         Defaults to True.
@@ -434,11 +437,13 @@ class GradientMonitoringCallback(tf.keras.callbacks.Callback):
         sample_dataset,
         loss_indices,
         log_dir=None,
+        log_as_dense=True,
         print_stats=True,
     ):
         super().__init__()
         self.sample_dataset = sample_dataset
         self.loss_indices = loss_indices
+        self.log_as_dense = log_as_dense
         self.print_stats = print_stats
 
         # Validate inputs
@@ -464,11 +469,31 @@ class GradientMonitoringCallback(tf.keras.callbacks.Callback):
         with tf.GradientTape() as tape:
             outputs = self.model(inputs, training=True)
             if len(self.loss_indices) > 1:
-                loss = [outputs[idx] for idx in self.loss_indices]
-                loss = tf.add_n(loss)
+                loss = tf.add_n([outputs[idx] for idx in self.loss_indices])
             else:
-                loss = outputs[self.loss_indices]
+                loss = outputs[self.loss_indices[0]]
         return tape.gradient(loss, self.model.trainable_variables)
+    
+    def _convert_grad_to_dense(self, gradient):
+        """Convert a gradient to a dense tensor if necessary.
+        
+        Parameters
+        ----------
+        gradient : tf.Tensor, tf.IndexedSlices, tf.SparseTensor
+            Gradient to convert to a dense tensor.
+        
+        Returns
+        -------
+        converted_gradient : tf.Tensor
+            Dense tensor representation of the gradient.
+        sparse_flag : bool
+            Flag indicating whether the gradient was originally sparse.
+        """
+        if isinstance(gradient, tf.IndexedSlices):
+            return tf.convert_to_tensor(gradient), True
+        elif isinstance(gradient, tf.SparseTensor):
+            return tf.sparse.to_dense(gradient), True
+        return gradient, False
 
     def on_epoch_end(self, epoch, logs=None):
         """Action to perform at the end of an epoch.
@@ -476,13 +501,14 @@ class GradientMonitoringCallback(tf.keras.callbacks.Callback):
         Parameters
         ---------
         epochs : int
-            Integer, index of epoch.
+            Index of epoch.
         logs : dict, optional
             Results for this training epoch, and for the validation epoch if
             validation is performed.
         """
         # Initialize accumulators for each trainable variable
         accumulated_gradients = [None] * len(self.model.trainable_variables)
+        sparse_flags = [True] * len(self.model.trainable_variables)
         batch_count = 0
 
         # Compute the loss and gradients on the sample dataset
@@ -492,11 +518,17 @@ class GradientMonitoringCallback(tf.keras.callbacks.Callback):
 
             # Accumulate gradients
             for i, grad in enumerate(gradients):
+                # Always convert to dense for correct accumulation
+                grad, sparse_flag = self._convert_grad_to_dense(grad)
                 if grad is not None:
                     if accumulated_gradients[i] is None:
                         accumulated_gradients[i] = grad
                     else:
                         accumulated_gradients[i] += grad
+                # If any batch gives a dense gradient, mark the overall flag as False
+                if sparse_flags[i] is True:
+                    sparse_flags[i] = sparse_flag
+                    # ensure that non-zero values are removed only if all gradients are sparse
             batch_count += 1
 
         # Average gradients over the batches
@@ -510,26 +542,40 @@ class GradientMonitoringCallback(tf.keras.callbacks.Callback):
 
         # Group gradients by layer
         layer_gradients = {}
-        for grad, var in zip(averaged_gradients, self.model.trainable_variables):
+        for i, (grad, var) in enumerate(zip(averaged_gradients, self.model.trainable_variables)):
             var_name = var.name
             layer_name = var_name.split("/")[0]  # get the first part as the layer name.
             if grad is not None:
-                layer_gradients.setdefault(layer_name, []).append((grad, var))
+                layer_gradients.setdefault(layer_name, []).append((grad, var, sparse_flags[i]))
 
         # Log and print gradient summary statistics for each layer
         with self.writer.as_default():
             for layer, grad_var_pairs in layer_gradients.items():
                 if self.print_stats:
                     print(f"\nLayer: {layer}")
-                for grad, var in grad_var_pairs:
+                for grad, var, flag in grad_var_pairs:
                     if grad is not None:
-                        grad_mean = tf.reduce_mean(grad)
-                        grad_std = tf.math.reduce_std(grad)
-                        grad_min = tf.reduce_min(grad)
-                        grad_max = tf.reduce_max(grad)
-                        grad_norm = tf.norm(grad)
 
-                        # Print summary statistics.
+                        if not self.log_as_dense and flag:
+                            # Log only non-zero entries, given that the gradient is sparse
+                            logged_grad = tf.boolean_mask(grad, tf.not_equal(grad, 0))
+                        else:
+                            # Log the full dense gradient
+                            logged_grad = grad
+
+                        # Compute summary statistics
+                        grad_mean = tf.reduce_mean(logged_grad)
+                        grad_std = tf.math.reduce_std(logged_grad)
+                        grad_min = tf.reduce_min(logged_grad)
+                        grad_max = tf.reduce_max(logged_grad)
+                        grad_norm = tf.norm(logged_grad)
+
+                        # Compute statistics for non-zero entries
+                        nonzero_mask = tf.not_equal(grad, 0)
+                        nonzero_vals = tf.boolean_mask(grad, nonzero_mask)
+                        nonzero_ratio = tf.cast(tf.size(nonzero_vals), tf.float32) / tf.cast(tf.size(grad), tf.float32)
+
+                        # Print summary statistics
                         if self.print_stats:
                             print(f"  {var.name}:")
                             print(
@@ -539,9 +585,14 @@ class GradientMonitoringCallback(tf.keras.callbacks.Callback):
                                 f"    Min: {grad_min.numpy():.5f}, Max: {grad_max.numpy():.5f}"
                             )
                             print(f"    L2 Norm: {grad_norm.numpy():.5f}")
+                            if flag:
+                                print(f"    Non-zero ratio: {nonzero_ratio.numpy():.5f}")
 
-                        # Log gradient histogram and scalar summaries.
-                        tf.summary.histogram(f"gradients/{var.name}", grad, step=epoch)
+                        # Log gradient histogram and scalar summaries
+                        if not self.log_as_dense and flag:
+                            tf.summary.histogram(f"gradients/{var.name}_nonzero", logged_grad, step=epoch)
+                        else:
+                            tf.summary.histogram(f"gradients/{var.name}", grad, step=epoch)
                         tf.summary.scalar(
                             f"gradients/{var.name}_mean", grad_mean, step=epoch
                         )
@@ -557,7 +608,10 @@ class GradientMonitoringCallback(tf.keras.callbacks.Callback):
                         tf.summary.scalar(
                             f"gradients/{var.name}_norm", grad_norm, step=epoch
                         )
+                        tf.summary.scalar(
+                            f"gradients/{var.name}_nonzero_ratio", nonzero_ratio, step=epoch
+                        )
                     else:
                         if self.print_stats:
-                            print(f"  {var.name}: Gradient is None")
+                            print(f"  {var.name}: Gradient is None.")
             self.writer.flush()


### PR DESCRIPTION
In the previous pull request (#321), I introduced `TensorBoardCallback` and `GradientMonitoringCallback` for logging weights, biases, and gradient updates during model training. This PR includes further enhancements and generalisations:

### Improvements:

- **`loss_indices` Argument:**
  - Users can now specify loss indices within their model outputs. This ensures broader compatibility across various model architectures, including those not yet registered in `osl_dynamics.models`.

- **Support for Sparse Gradient Data Types:**
  - TensorFlow gradients may come in various data types, including sparse tensors. This PR introduces functionality to convert sparse gradients into dense tensors for logging purposes.
  - Users have the option to preserve or discard zero values within sparse gradients.
  - Summary statistics, such as the ratio of non-zero values, are provided for enhanced interpretability.

- **Merging Multiple Event Files:**
  - Large models that exceed memory or computational constraints often require training one epoch at a time, resulting in separate TensorBoard event files per epoch. The callbacks now support seamless merging of multiple event files, ensuring continuous and coherent logging of weights and gradient distributions across epochs.

### Developer Notes:

- Currently, logging does not support ragged tensors. This feature can be added in future updates if required.
- The callbacks are optimised specifically for epoch-level logging. Batch-level logging will require further modifications if necessary.