### PR TITLE
Use MAP estimate in Gumbel-Softmax sampling during inference

### DIFF
--- a/osl_dynamics/inference/layers.py
+++ b/osl_dynamics/inference/layers.py
@@ -382,12 +382,16 @@ class SampleGumbelSoftmaxDistributionLayer(layers.Layer):
             temperature, trainable=False, dtype=tf.float32, name="gs_temperature"
         )
 
-    def call(self, inputs, **kwargs):
+    def call(self, inputs, training=None, **kwargs):
         """This method accepts logits and outputs samples."""
-        gs = tfp.distributions.RelaxedOneHotCategorical(
-            temperature=self.temperature, logits=inputs
-        )
-        return gs.sample()
+        if training:
+            gs = tfp.distributions.RelaxedOneHotCategorical(
+                temperature=self.temperature, logits=inputs
+            )
+            return gs.sample()
+        else:
+            softmaxed_logits = tf.nn.softmax(inputs / self.temperature, axis=-1)
+            return softmaxed_logits
 
 
 class SampleOneHotCategoricalDistributionLayer(layers.Layer):


### PR DESCRIPTION
### Description:
This pull request updates the behaviour of the `call()` function in the `SampleGumbelSoftmaxDistributionLayer` class to handle training and inference phases differently.

During training, the layer samples from the Gumbel-Softmax distribution, maintaining stochasticity. However, during inference (prediction or testing), it uses the MAP estimate by applying a softmax to the logits with the specified temperature, without adding Gumbel noise.

This approach aligns the inference behaviour of `SampleGumbelSoftmaxDistributionLayer` with the established practices used in `SampleNormalDistributionLayer`.

