### PR TITLE
Enhance: Gumbel-Softmax annealing during initialization 

### DIFF
--- a/osl_dynamics/models/dyneste.py
+++ b/osl_dynamics/models/dyneste.py
@@ -434,6 +434,177 @@ class Model(VariationalInferenceModelBase):
 
         return super().fit(*args, **kwargs)
 
+    def random_subset_initialization(
+        self,
+        training_data,
+        n_epochs,
+        n_init,
+        take,
+        n_kl_annealing_epochs=None,
+        do_gs_annealing=None,
+        **kwargs,
+    ):
+        """Random subset initialization.
+
+        This function inherits :code:`random_subset_initialization()` in
+        :code:`VariationalInferenceModelBase`.
+
+        Parameters
+        ----------
+        training_data : tf.data.Dataset or osl_dynamics.data.Data
+            Dataset to use for training.
+        n_epochs : int
+            Number of epochs to train the model.
+        n_init : int
+            Number of initializations.
+        take : float
+            Fraction of total batches to take.
+        n_kl_annealing_epochs : int, optional
+            Number of KL annealing epochs.
+        do_gs_annealing : bool, optional
+            Whether to anneal the Gumbel-Softmax temperature during
+            initialization. Defaults to None, in which case the value
+            set in the configuration will be used.
+        kwargs : keyword arguments, optional
+            Keyword arguments for the fit method.
+
+        Returns
+        -------
+        history : history
+            The training history of the best initialization.
+        """
+        # Original Gumbel-Softmax annealing flag
+        original_gs_flag = self.config.do_gs_annealing
+
+        # Use do_gs_annealing if passed
+        if do_gs_annealing is not None:
+            self.config.do_gs_annealing = do_gs_annealing
+
+        # Run initialization
+        history = super().random_subset_initialization(
+            training_data,
+            n_epochs,
+            n_init,
+            take,
+            n_kl_annealing_epochs=n_kl_annealing_epochs,
+            **kwargs,
+        )
+
+        # Reset Gumbel-Softmax annealing flag
+        self.config.do_gs_annealing = original_gs_flag
+
+        return history
+
+    def single_subject_initialization(
+        self,
+        training_data,
+        n_epochs,
+        n_init,
+        n_kl_annealing_epochs=None,
+        do_gs_annealing=None,
+        **kwargs,
+    ):
+        """Initialization for the state means/covariances.
+
+        This function inherits :code:`single_subject_initialization()` in
+        :code:`VariationalInferenceModelBase`.
+
+        Parameters
+        ----------
+        training_data : list of tf.data.Dataset or osl_dynamics.data.Data
+            Datasets for each subject.
+        n_epochs : int
+            Number of epochs to train.
+        n_init : int
+            How many subjects should we train on?
+        n_kl_annealing_epochs : int, optional
+            Number of KL annealing epochs to use during initialization. If
+            :code:`None` then the KL annealing epochs in the :code:`config`
+            is used.
+        kwargs : keyword arguments, optional
+            Keyword arguments for the fit method.
+        """
+        # Original Gumbel-Softmax annealing flag
+        original_gs_flag = self.config.do_gs_annealing
+
+        # Use do_gs_annealing if passed
+        if do_gs_annealing is not None:
+            self.config.do_gs_annealing = do_gs_annealing
+
+        # Run initialization
+        super().single_subject_initialization(
+            training_data,
+            n_epochs,
+            n_init,
+            n_kl_annealing_epochs=n_kl_annealing_epochs,
+            **kwargs,
+        )
+
+        # Reset Gumbel-Softmax annealing flag
+        self.config.do_gs_annealing = original_gs_flag
+
+    def random_state_time_course_initialization(
+        self,
+        training_data,
+        n_epochs,
+        n_init,
+        take=1,
+        stay_prob=0.9,
+        do_gs_annealing=None,
+        **kwargs,
+    ):
+        """Random state time course initialization.
+
+        This function inherits :code:`random_state_time_course_initialization()`
+        in :code:`VariationalInferenceModelBase`.
+
+        Parameters
+        ----------
+        training_data : tf.data.Dataset or osl_dynamics.data.Data
+            Dataset to use for training.
+        n_epochs : int
+            Number of epochs to train the model.
+        n_init : int
+            Number of initializations.
+        take : float, optional
+            Fraction of total batches to take.
+        stay_prob : float, optional
+            Stay probability (diagonal for the transition probability
+            matrix). Other states have uniform probability.
+        do_gs_annealing : bool, optional
+            Whether to anneal the Gumbel-Softmax temperature during
+            initialization. Defaults to None, in which case the value
+            set in the configuration will be used.
+        kwargs : keyword arguments, optional
+            Keyword arguments for the fit method.
+
+        Returns
+        -------
+        history : history
+            The training history of the best initialization.
+        """
+        # Original Gumbel-Softmax annealing flag
+        original_gs_flag = self.config.do_gs_annealing
+
+        # Use do_gs_annealing if passed
+        if do_gs_annealing is not None:
+            self.config.do_gs_annealing = do_gs_annealing
+
+        # Run initialization
+        history = super().random_state_time_course_initialization(
+            training_data,
+            n_epochs,
+            n_init,
+            take,
+            stay_prob,
+            **kwargs,
+        )
+
+        # Reset Gumbel-Softmax annealing flag
+        self.config.do_gs_annealing = original_gs_flag
+
+        return history
+
     def get_means(self):
         """Get the state means.
 


### PR DESCRIPTION
This pull request adds separate initialisation functions for `dyneste.py`, enabling the optional temperature annealing during initialisation via a new argument `do_gs_annealing`.

Typically, annealing the temperature of the Gumbel-Softmax distribution may not be desirable during initialisation. This is because, after initialisation, the model begins its training from the original (un-annealed) temperature, which can potentially introduce unnecessary complexity as the initial weights are learned with annealed temperature.

Users now have the flexibility to explicitly control the temperature annealing during initialisation based on their specific requirements (e.g., their chosen number of initialisation epochs).