### PR TITLE
Regularization Scaling Factor

### DIFF
--- a/osl_dynamics/data/tf.py
+++ b/osl_dynamics/data/tf.py
@@ -439,8 +439,8 @@ def get_n_batches(dataset):
     return cardinality.numpy()
 
 
-def get_n_batches_and_range(dataset):
-    """Get number of batches and range (max-min) of values.
+def get_n_sequences_and_range(dataset):
+    """Get number of sequences and range (max-min) of values.
 
     Parameters
     ----------
@@ -449,12 +449,12 @@ def get_n_batches_and_range(dataset):
 
     Returns
     -------
-    n_batches : int
+    n_sequences : int
         Number of batches.
     range_ : np.ndarray
         Range of each channel.
     """
-    count = 0
+    n_sequences = 0
     amax = []
     amin = []
     dataset = _validate_tf_dataset(dataset)
@@ -462,9 +462,10 @@ def get_n_batches_and_range(dataset):
         if isinstance(batch, dict):
             batch = batch["data"]
         batch = batch.numpy()
-        n_channels = batch.shape[-1]
+        batch_size, _, n_channels = batch.shape
         batch = batch.reshape(-1, n_channels)
         amin.append(np.amin(batch, axis=0))
         amax.append(np.amax(batch, axis=0))
-        count += 1
-    return count, np.amax(amax, axis=0) - np.amin(amin, axis=0)
+        n_sequences += batch_size
+    range_ = np.amax(amax, axis=0) - np.amin(amin, axis=0)
+    return n_sequences, range_

--- a/osl_dynamics/models/dive.py
+++ b/osl_dynamics/models/dive.py
@@ -848,12 +848,10 @@ class Model(VariationalInferenceModelBase):
         _logger.info("Setting regularizers")
 
         training_dataset = self.make_dataset(
-            training_dataset,
-            shuffle=False,
-            concatenate=True,
+            training_dataset, shuffle=False, concatenate=True
         )
-        n_batches, range_ = dtf.get_n_batches_and_range(training_dataset)
-        scale_factor = self.get_static_loss_scaling_factor(n_batches)
+        n_sequences, range_ = dtf.get_n_sequences_and_range(training_dataset)
+        scale_factor = self.get_static_loss_scaling_factor(n_sequences)
 
         if self.config.learn_means:
             # Group means

--- a/osl_dynamics/models/dynemo.py
+++ b/osl_dynamics/models/dynemo.py
@@ -454,8 +454,8 @@ class Model(VariationalInferenceModelBase):
         training_dataset = self.make_dataset(
             training_dataset, shuffle=False, concatenate=True
         )
-        n_batches, range_ = dtf.get_n_batches_and_range(training_dataset)
-        scale_factor = self.get_static_loss_scaling_factor(n_batches)
+        n_sequences, range_ = dtf.get_n_sequences_and_range(training_dataset)
+        scale_factor = self.get_static_loss_scaling_factor(n_sequences)
 
         if self.config.learn_means:
             obs_mod.set_means_regularizer(self.model, range_, scale_factor)

--- a/osl_dynamics/models/dyneste.py
+++ b/osl_dynamics/models/dyneste.py
@@ -722,8 +722,8 @@ class Model(VariationalInferenceModelBase):
         training_dataset = self.make_dataset(
             training_dataset, shuffle=False, concatenate=True
         )
-        n_batches, range_ = dtf.get_n_batches_and_range(training_dataset)
-        scale_factor = self.get_static_loss_scaling_factor(n_batches)
+        n_sequences, range_ = dtf.get_n_sequences_and_range(training_dataset)
+        scale_factor = self.get_static_loss_scaling_factor(n_sequences)
 
         if self.config.learn_means:
             obs_mod.set_means_regularizer(self.model, range_, scale_factor)

--- a/osl_dynamics/models/hive.py
+++ b/osl_dynamics/models/hive.py
@@ -945,12 +945,10 @@ class Model(MarkovStateInferenceModelBase):
         _logger.info("Setting regularizers")
 
         training_dataset = self.make_dataset(
-            training_dataset,
-            shuffle=False,
-            concatenate=True,
+            training_dataset, shuffle=False, concatenate=True
         )
-        n_batches, range_ = dtf.get_n_batches_and_range(training_dataset)
-        scale_factor = self.get_static_loss_scaling_factor(n_batches)
+        n_sequences, range_ = dtf.get_n_sequences_and_range(training_dataset)
+        scale_factor = self.get_static_loss_scaling_factor(n_sequences)
 
         if self.config.learn_means:
             # Group means

--- a/osl_dynamics/models/hmm.py
+++ b/osl_dynamics/models/hmm.py
@@ -348,8 +348,8 @@ class Model(MarkovStateInferenceModelBase):
         training_dataset = self.make_dataset(
             training_dataset, shuffle=False, concatenate=True
         )
-        n_batches, range_ = dtf.get_n_batches_and_range(training_dataset)
-        scale_factor = self.get_static_loss_scaling_factor(n_batches)
+        n_sequences, range_ = dtf.get_n_sequences_and_range(training_dataset)
+        scale_factor = self.get_static_loss_scaling_factor(n_sequences)
 
         if self.config.learn_means:
             obs_mod.set_means_regularizer(self.model, range_, scale_factor)

--- a/osl_dynamics/models/inf_mod_base.py
+++ b/osl_dynamics/models/inf_mod_base.py
@@ -203,10 +203,7 @@ class VariationalInferenceModelBase(ModelBase):
 
         # Make a TensorFlow Dataset
         training_dataset = self.make_dataset(
-            training_data,
-            shuffle=True,
-            concatenate=True,
-            drop_last_batch=True,
+            training_data, shuffle=True, concatenate=True
         )
 
         # Calculate the number of batches to use
@@ -416,10 +413,7 @@ class VariationalInferenceModelBase(ModelBase):
 
         # Make a TensorFlow Dataset
         training_dataset = self.make_dataset(
-            training_data,
-            shuffle=True,
-            concatenate=True,
-            drop_last_batch=True,
+            training_data, shuffle=True, concatenate=True
         )
 
         # Calculate the number of batches to use
@@ -1291,10 +1285,7 @@ class MarkovStateInferenceModelBase(ModelBase):
 
         # Make a TensorFlow Dataset
         training_dataset = self.make_dataset(
-            training_data,
-            shuffle=True,
-            concatenate=True,
-            drop_last_batch=True,
+            training_data, shuffle=True, concatenate=True
         )
 
         # Calculate the number of batches to use
@@ -1377,10 +1368,7 @@ class MarkovStateInferenceModelBase(ModelBase):
 
         # Make a TensorFlow Dataset
         training_dataset = self.make_dataset(
-            training_data,
-            shuffle=True,
-            concatenate=True,
-            drop_last_batch=True,
+            training_data, shuffle=True, concatenate=True
         )
 
         # Calculate the number of batches to use

--- a/osl_dynamics/models/mdynemo.py
+++ b/osl_dynamics/models/mdynemo.py
@@ -591,8 +591,8 @@ class Model(VariationalInferenceModelBase):
         training_dataset = self.make_dataset(
             training_dataset, shuffle=False, concatenate=True
         )
-        n_batches, range_ = dtf.get_n_batches_and_range(training_dataset)
-        scale_factor = self.get_static_loss_scaling_factor(n_batches)
+        n_sequences, range_ = dtf.get_n_sequences_and_range(training_dataset)
+        scale_factor = self.get_static_loss_scaling_factor(n_sequences)
 
         if self.config.learn_means:
             obs_mod.set_means_regularizer(self.model, range_, scale_factor)

--- a/osl_dynamics/models/mod_base.py
+++ b/osl_dynamics/models/mod_base.py
@@ -250,7 +250,6 @@ class ModelBase:
             x,
             shuffle=True,
             concatenate=True,
-            drop_last_batch=True,
             repeat_count=repeat_count,
         )
         args, kwargs = replace_argument(self.model.fit, "x", x, args, kwargs)

--- a/osl_dynamics/models/mod_base.py
+++ b/osl_dynamics/models/mod_base.py
@@ -459,7 +459,7 @@ class ModelBase:
             concatenate=concatenate,
         )
 
-    def get_static_loss_scaling_factor(self, n_batches):
+    def get_static_loss_scaling_factor(self, n_sequences):
         """Get scaling factor for static losses.
 
         When calculating loss, we want to approximate the effect of the
@@ -468,8 +468,8 @@ class ModelBase:
 
         Parameters
         ----------
-        n_batches : int
-            Total number of batches in the training dataset.
+        n_sequences : int
+            Total number of sequences in the training dataset.
 
         Returns
         -------
@@ -477,7 +477,6 @@ class ModelBase:
             Scale factor for 'static' losses, i.e. those which are not
             time varying.
         """
-        n_sequences = self.config.batch_size * n_batches
         scale_factor = 1.0 / n_sequences
         if self.config.loss_calc == "mean":
             scale_factor /= self.config.sequence_length


### PR DESCRIPTION
Changes:
- Unified the use of `drop_last_batch` (to `False`) when generating a dataset inside a model.
- Use the actual count of sequences to calculate the regularization scale factor (rather than an approximate based on batch_size*num_batches).