### PR TITLE
More memory efficient method for getting HMM state probabilities

### DIFF
--- a/osl_dynamics/models/inf_mod_base.py
+++ b/osl_dynamics/models/inf_mod_base.py
@@ -1134,8 +1134,11 @@ class MarkovStateInferenceModelBase(ModelBase):
 
         alpha = []
         for i in iterator:
-            predictions = self.predict(dataset[i], **kwargs)
-            alpha_ = predictions["gamma"]
+            alp = []
+            for batch in dataset[i]:
+                pred = self.predict(batch, **kwargs)
+                alp.append(pred["gamma"])
+            alpha_ = np.concatenate(alp)  # concat over batches
             if remove_edge_effects:
                 trim = step_size // 2  # throw away 25%
                 alpha_ = (


### PR DESCRIPTION
Changes:
- Tweaked `hmm.Model.get_alpha` to iterate over batches (rather than subjects) to avoid OOM (out of memory) errors.