### PR TITLE
Fix: avoid error in TINDA when there's no state activation

### DIFF
--- a/osl_dynamics/analysis/tinda.py
+++ b/osl_dynamics/analysis/tinda.py
@@ -476,6 +476,10 @@ def tinda(
 
         for i in range(dim[1]):
             itc_prim = tc[:, i]
+            if np.all(itc_prim == 0):
+                print(f"Skipping state {i}: no activations detected.")
+                continue
+            
             if not np.array_equal(
                 itc_prim, itc_prim.astype(int)
             ):  # if not binary (i.e., intervals are not well defined)


### PR DESCRIPTION
Closes: https://github.com/OHBA-analysis/osl-dynamics/issues/369.

Changes:
- Check if a state time course doesn't activate and skip if so.