### PR TITLE
Option to remove subcortical voxels when plotting power maps.

### DIFF
--- a/osl_dynamics/utils/plotting.py
+++ b/osl_dynamics/utils/plotting.py
@@ -1603,6 +1603,7 @@ def plot_brain_surface(
     views=None,
     bg_on_data=False,
     threshold=None,
+    remove_subcortical_voxels=False,
     filename=None,
     show_plot=None,
 ):
@@ -1637,7 +1638,7 @@ def plot_brain_surface(
     vmax : float, optional
         Maximum value for the color bar.
         May be overridden if :code:`symmetric_cbar=True`.
-    hemispheres : list, optional.
+    hemispheres : list, optional
         :code:`['left', 'right']` or :code:`['left']` or :code:`['right']`.
         Defaults to :code:`['left', 'right']`.
     views : list, optional
@@ -1652,6 +1653,8 @@ def plot_brain_surface(
         or because is was thresholded).
     threshold : float, optional
         Threshold values to display. Defaults to no thresholding.
+    remove_subcortical_voxels : bool, optional
+        Should we set the subcortical voxels to np.nan?
     filename : str, optional
         Output filename. Extension can be :code:`png/svg/pdf`.
         If None is passed then the image is shown on screen and the
@@ -1699,7 +1702,9 @@ def plot_brain_surface(
     )
 
     # Convert from parcel values to voxel values
-    values = parcel_vector_to_voxel_grid(mask_file, parcellation_file, values)
+    values = parcel_vector_to_voxel_grid(
+        mask_file, parcellation_file, values, remove_subcortical_voxels
+    )
 
     # Create image to plot
     mask = nib.load(mask_file)


### PR DESCRIPTION
Closes https://github.com/OHBA-analysis/osl-dynamics/issues/364.

Changes:
- Added a new argument `remove_subcortical_voxels` that can be used to remove subcortical voxels (set voxel values to nan) when plotting plot maps.

Note: we hard code the voxel indices for subcortical regions. **They are only valid for 8x8x8 mm grids** (in MNI space).

Example use:
```
import numpy as np
from osl_dynamics.analysis import power
from matplotlib.colors import LinearSegmentedColormap

colors = [(1, 0, 0, 1), (.5, .5, .5, .5)]
cmap_pval = LinearSegmentedColormap.from_list("cmap", colors, N=256)

pvals = np.ones(52)
power.save(
    pvals,
    mask_file="MNI152_T1_8mm_brain.nii.gz",
    parcellation_file="Glasser52_binary_space-MNI152NLin6_res-8x8x8.nii.gz",
    plot_kwargs={
        "cmap": cmap_pval,
        "views": ["lateral", "medial"],
        "vmin": 0,
        "vmax": 0.05,
        "symmetric_cbar": False,
        "remove_subcortical_voxels": True,
    },
    filename="plot_.png",
)
```