### PR TITLE
Add diagonal covariance option for dual estimation + hmm_features

### DIFF
--- a/osl_dynamics/analysis/post_hoc.py
+++ b/osl_dynamics/analysis/post_hoc.py
@@ -939,10 +939,10 @@ def hmm_features(
     alpha,
     sampling_frequency=None,
     zero_mean=False,
+    diagonal_covariances=False,
     eps=1e-5,
     use_partial=False,
     n_jobs=1,
-    diagonal_covariances=False,
 ):
     """Dual estimation of HMM features.
 
@@ -959,6 +959,9 @@ def hmm_features(
         are unitless.
     zero_mean : bool, optional
         Should we force the state means to be zero?
+    diagonal_covariances : bool, optional
+        If True, estimate diagonal covariance matrices (variances only)
+        and return them as full matrices with zeros off-diagonal.
     eps : float, optional
         Small value to add to the diagonal of each state covariance.
     use_partial : bool, optional
@@ -967,9 +970,6 @@ def hmm_features(
         reduces to per-channel variance terms on the diagonal.
     n_jobs : int, optional
         Number of jobs to run in parallel.
-    diagonal_covariances : bool, optional
-        If True, estimate diagonal covariance matrices (variances only)
-        and return them as full matrices with zeros off-diagonal.
 
     Returns
     -------

--- a/osl_dynamics/models/hmm.py
+++ b/osl_dynamics/models/hmm.py
@@ -444,9 +444,9 @@ class Model(MarkovStateInferenceModelBase):
             data,
             alpha,
             zero_mean=(not self.config.learn_means),
+            diagonal_covariances=self.config.diagonal_covariances,
             eps=self.config.covariances_epsilon,
             n_jobs=n_jobs,
-            diagonal_covariances=self.config.diagonal_covariances,
         )
 
         return means, covariances


### PR DESCRIPTION
## Summary

This PR adds support for diagonal covariance matrices in the HMM dual estimation pipeline, matching the existing capability in the main HMM model (`config.diagonal_covariances`). This enables session-specific re-estimation of variance-only observation models, useful for parcellations or analyses where cross-channel covariance structure is not required or not identifiable.

## Key changes

- Extend `hmm_dual_estimation` (in `analysis/post_hoc.py`) with a new argument `diagonal_covariances=False`.
- Implement efficient diagonal-only covariance estimation (weighted per-channel variances).
- Ensure returned matrices remain full (`n_channels × n_channels`) with off-diagonals zeroed.
- Update `hmm_features` to:
  - pass through the new option,
  - extract diagonal terms when `diagonal_covariances=True`,
  - maintain consistency with optional partial correlation transforms.
- Update `Model.dual_estimation` to respect `config.diagonal_covariances`.
- Update and expand relevant docstrings.

## Motivation

Enable dual-estimation workflows where only state-specific variances are needed (e.g., amplitude/power-driven dynamics), consistent with the diagonal-covariance option already available during HMM training. This brings feature parity to post-hoc analysis functions.

## Notes

- Full-covariance behaviour is unchanged.
- The diagonal option is opt-in and affects only explicit uses.
- Tested on synthetic data to ensure off-diagonal entries remain zero and behaviour is correct.
