### PR TITLE
Fixes for spectral/covariance calculations

### DIFF
--- a/osl_dynamics/analysis/power.py
+++ b/osl_dynamics/analysis/power.py
@@ -135,6 +135,12 @@ def variance_from_spectra(
         Variance over a frequency band for each component of each mode.
         Shape is (n_components, n_modes, n_channels) or (n_modes, n_channels)
         or (n_channels,).
+
+    Notes
+    -----
+    To get the correct scaling so that the output of this function reflects
+    the variance of the original data, then :code:`method='integral'` should
+    be used. Otherwise, the output of this function has an arbitrary scaling.
     """
 
     # Validation

--- a/osl_dynamics/analysis/spectral.py
+++ b/osl_dynamics/analysis/spectral.py
@@ -1582,10 +1582,10 @@ def _welch(
         # Average over the time dimension and rescale
         p = np.mean(p, axis=0)
         p *= scaling[i]
+        n_freq = p.shape[-1]
 
         if calc_coh:
             # Create a channels by channels matrix for cross PSDs
-            n_freq = p.shape[-1]
             cpsd = np.empty(
                 [n_channels, n_channels, n_freq],
                 dtype=np.complex64,
@@ -1598,6 +1598,16 @@ def _welch(
 
             # Calculate coherence
             coh.append(coherence_spectra(cpsd))
+
+        elif calc_cpsd:
+            cpsd = np.empty(
+                [n_channels, n_channels, n_freq],
+                dtype=np.complex64,
+            )
+            cpsd[m, n] = p
+            cpsd[n, m] = np.conj(p)
+            psd.append(cpsd)
+
         else:
             psd.append(p)
 

--- a/osl_dynamics/analysis/static.py
+++ b/osl_dynamics/analysis/static.py
@@ -226,6 +226,7 @@ def welch_spectra(
         step_size=step_size,
         frequency_range=frequency_range,
         standardize=standardize,
+        calc_cpsd=calc_cpsd,
         calc_coh=calc_coh,
         return_weights=return_weights,
         keepdims=keepdims,


### PR DESCRIPTION
Changes:
- Fixed cross spectra calculations.
- Tested covariance calculated from the data matches that calculated directly from the time series data.
- Updated the docs.

Tested the code with:
```
import numpy as np
from osl_dynamics.data.processing import standardize
from osl_dynamics.analysis import static, power, connectivity
from osl_dynamics.data import Data

n_channels = 5
fs = 50

m = np.zeros(n_channels)
W = np.random.normal(size=[n_channels, n_channels])
C = W @ W.T + 1e-5 * np.eye(n_channels)

X = np.random.multivariate_normal(m, C, size=20000)

data = Data(X, sampling_frequency=fs)

f, psd = static.welch_spectra(X, sampling_frequency=fs, window_length=500, standardize=False)
p = power.variance_from_spectra(f, psd, method='integral', frequency_range=[10, 12])

f, cpsd = static.welch_spectra(X, sampling_frequency=fs, window_length=500, standardize=False, calc_cpsd=True)
c = connectivity.covariance_from_spectra(f, cpsd, frequency_range=[10, 12])

data.filter(low_freq=10, high_freq=12)
X = data.time_series()
cov = np.cov(X.T)

print("original:", np.diagonal(cov))
print("from psd:", p)

print("original:")
print(cov)
print("from cpsd:")
print(c)
```