### PR TITLE
Suggestion to compute eigenvalues of covariance matrix instead of SVD

### DIFF
--- a/osl_dynamics/data/base.py
+++ b/osl_dynamics/data/base.py
@@ -12,7 +12,6 @@ from shutil import rmtree
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple, Union
 
-from scipy.sparse.linalg import eigsh
 import numpy as np
 from pqdm.threads import pqdm
 from threadpoolctl import threadpool_limits
@@ -722,7 +721,7 @@ class Data:
                 std_data = processing.standardize(array)
                 covariance += np.transpose(std_data) @ std_data
             # Compute covariance eigenvalues to obtain PCA components
-            s, u = eigsh(covariance, k=n_pca_components, which="LM")
+            s, u = misc.top_eig(covariance, n_pca_components)
             idx = np.argsort(s)[::-1]
             s = s[idx]
             u = u[:, idx]
@@ -870,7 +869,7 @@ class Data:
                 te_std_data = processing.time_embed(std_data, n_embeddings)
                 covariance += te_std_data.T @ te_std_data
             # Compute covariance eigenvalues to obtain PCA components
-            s, u = eigsh(covariance, k=n_pca_components, which="LM")
+            s, u = misc.top_eig(covariance, n_pca_components)
             idx = np.argsort(s)[::-1]
             s = s[idx]
             u = u[:, idx]

--- a/osl_dynamics/data/base.py
+++ b/osl_dynamics/data/base.py
@@ -12,6 +12,7 @@ from shutil import rmtree
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple, Union
 
+from scipy.sparse.linalg import eigsh
 import numpy as np
 from pqdm.threads import pqdm
 from threadpoolctl import threadpool_limits
@@ -720,13 +721,15 @@ class Data:
             for array in tqdm(arrays, desc="Calculating PCA components"):
                 std_data = processing.standardize(array)
                 covariance += np.transpose(std_data) @ std_data
-
-            # Use SVD on the covariance to calculate PCA components
-            u, s, vh = np.linalg.svd(covariance)
-            u = u[:, :n_pca_components].astype(np.float32)
-            self.explained_variance = np.sum(s[:n_pca_components]) / np.sum(s)
+            # Compute covariance eigenvalues to obtain PCA components
+            s, u = eigsh(covariance, k=n_pca_components, which="LM")
+            idx = np.argsort(s)[::-1]
+            s = s[idx]
+            u = u[:, idx]
+            self.explained_variance = np.sum(s) / np.trace(covariance)
             _logger.info(f"Explained variance: {100 * self.explained_variance:.1f}%")
-            s = s[:n_pca_components].astype(np.float32)
+            s = s.astype(np.float32)
+            u = u.astype(np.float32)
             if whiten:
                 u = u @ np.diag(1.0 / np.sqrt(s))
             self.pca_components = u
@@ -861,18 +864,20 @@ class Data:
         # Calculate PCA on TDE data
         if n_pca_components is not None:
             # Calculate covariance of the data
-            covariance = np.zeros([self.n_te_channels, self.n_te_channels])
+            covariance = np.zeros((self.n_te_channels, self.n_te_channels), dtype=np.float64)
             for array in tqdm(arrays, desc="Calculating PCA components"):
                 std_data = processing.standardize(array)
                 te_std_data = processing.time_embed(std_data, n_embeddings)
-                covariance += np.transpose(te_std_data) @ te_std_data
-
-            # Use SVD on the covariance to calculate PCA components
-            u, s, vh = np.linalg.svd(covariance)
-            u = u[:, :n_pca_components].astype(np.float32)
-            self.explained_variance = np.sum(s[:n_pca_components]) / np.sum(s)
+                covariance += te_std_data.T @ te_std_data
+            # Compute covariance eigenvalues to obtain PCA components
+            s, u = eigsh(covariance, k=n_pca_components, which="LM")
+            idx = np.argsort(s)[::-1]
+            s = s[idx]
+            u = u[:, idx]
+            self.explained_variance = np.sum(s) / np.trace(covariance)
             _logger.info(f"Explained variance: {100 * self.explained_variance:.1f}%")
-            s = s[:n_pca_components].astype(np.float32)
+            s = s.astype(np.float32)
+            u = u.astype(np.float32)
             if whiten:
                 u = u @ np.diag(1.0 / np.sqrt(s))
             self.pca_components = u

--- a/osl_dynamics/utils/misc.py
+++ b/osl_dynamics/utils/misc.py
@@ -57,6 +57,26 @@ def leading_zeros(number: int, largest_number: int) -> str:
     padded_number = str(number).zfill(min_length)
     return padded_number
 
+def top_eig(M, k):
+    """Compute the eigenvalue and eigenvalues of a matrix
+
+    This function uses either scipy.sparse.linalg.eigsh (for large matrices and
+    a smaller number of eigenvectors) or numpy.linalg.eigh (for smaller matrices
+    or full eigendecomposition)
+    """
+    from scipy.sparse.linalg import eigsh
+    n = M.shape[0]
+    if n > 300 and k < n // 2:
+        try:
+            vals, vecs = eigsh(M, k=k, which="LM")
+            idx = np.argsort(-vals)
+            return vals[idx], vecs[:, idx]
+        except (RuntimeError, ArpackNoConvergence):
+            pass
+    vals, vecs = np.linalg.eigh(M)
+    if k < n:
+        return vals[-k:], vecs[:, -k:]
+    return vals, vecs
 
 def override_dict_defaults(
     default_dict: dict, override_dict: Optional[dict] = None

--- a/osl_dynamics/utils/misc.py
+++ b/osl_dynamics/utils/misc.py
@@ -64,7 +64,7 @@ def top_eig(M, k):
     a smaller number of eigenvectors) or numpy.linalg.eigh (for smaller matrices
     or full eigendecomposition)
     """
-    from scipy.sparse.linalg import eigsh
+    from scipy.sparse.linalg import eigsh, ArpackNoConvergence
     n = M.shape[0]
     if n > 300 and k < n // 2:
         try:


### PR DESCRIPTION
Dear osl-dynamics maintainers, I recently tried out osl-dynamics, but found that the PCA and TDE-PCA operations were slower than I would have expected. In my own analyses, I usually use the scipy.sparse.linalg.eigsh function to compute only the eigenvalues of the covariance matrix which are needed, while osl-dynamics currently computes the full SVD of the covariance matrix. If the number of channels is large, I found that this can be quite slow. Thus, I wanted to make the suggestion to use eigsh instead, which I am currently using locally to save computation time.