### PR TITLE
Tinda optimisation

### DIFF
--- a/osl_dynamics/analysis/tinda.py
+++ b/osl_dynamics/analysis/tinda.py
@@ -220,15 +220,17 @@ def compute_fo_stats(
         interval_weighted_avg_all = []
         interval_sum_all = []
         for j, mask in enumerate(interval_mask):
-            temp_to_flat = np.concatenate([temp_to[k] for k in np.where(mask == 1)[0]])
-            temp_away_flat = np.concatenate(
-                [temp_away[k] for k in np.where(mask == 1)[0]]
-            )
+            temp_to_list = [temp_to[k] for k in np.where(mask == 1)[0]]
+            temp_away_list = [temp_away[k] for k in np.where(mask == 1)[0]]
 
-            interval_weighted_avg[:, 0, j] = np.mean(temp_away_flat, axis=0)
-            interval_weighted_avg[:, 1, j] = np.mean(temp_to_flat, axis=0)
-            interval_sum[:, 0, j] = np.sum(temp_away_flat, axis=0)
-            interval_sum[:, 1, j] = np.sum(temp_to_flat, axis=0)
+            # Originally, we were concatenating the arrays and then taking the mean, 
+            # but the intervals can be of different lengths (equivalent to weight each intervals with its duration?). 
+            # Instead, we take the temporal mean of each interval and then take the mean of those means.
+            interval_weighted_avg[:, 0, j] = np.mean([tmp_to.mean(0) for tmp_to in temp_to_list], axis=0)
+            interval_weighted_avg[:, 1, j] = np.mean([tmp_away.mean(0) for tmp_away in temp_away_list], axis=0)
+            #TODO I am not sure what we should do about the sum.
+            interval_sum[:, 0, j] = np.sum(np.concatenate(temp_away_list, axis = 0), axis=0)
+            interval_sum[:, 1, j] = np.sum(np.concatenate(temp_to_list, axis = 0), axis=0)
             interval_weighted_avg_all.append(
                 np.transpose(
                     np.stack(
@@ -643,6 +645,8 @@ def optimise_sequence(
         List of best sequence of states to plot (in order of counterclockwise
         rotation).
     """
+    from scipy.special import factorial
+    from itertools import permutations
     if len(fo_density.shape) == 5:
         fo_density = np.squeeze(fo_density)
 
@@ -668,18 +672,32 @@ def optimise_sequence(
     for i in range(n_metrics):
         ix = np.arange(K)
         v = np.imag(np.sum(circle_angles(ix) * metric[i]))
-        cnt = 0
-        while cnt < n_perms:
-            cnt += 1
-            swaps = np.random.permutation(K)
-            swaps = swaps[:2]
-            tmpix = ix.copy()
-            tmpix[swaps[0]] = ix[swaps[1]]
-            tmpix[swaps[1]] = ix[swaps[0]]
-            tmpv = np.imag(np.sum(circle_angles(tmpix) * metric[i]))
-            if tmpv < v:
-                v = tmpv
-                ix = tmpix
+        if factorial(K-1) < n_perms:
+            # If the number of permutations is less than n_perms, then we can compute all permutations and find the best one
+            def circular_permutations(arr):
+                arr = np.asarray(arr)
+                first = arr[0]
+                rest = arr[1:]
+                return np.array([[first, *p] for p in permutations(rest)])
+            all_perms = circular_permutations(ix)
+            for p in all_perms:
+                tmpv = np.imag(np.sum(circle_angles(p) * metric[i]))
+                if tmpv < v:
+                    v = tmpv
+                    ix = p
+        else:
+            cnt = 0
+            while cnt < n_perms:
+                cnt += 1
+                swaps = np.random.permutation(K)
+                swaps = swaps[:2]
+                tmpix = ix.copy()
+                tmpix[swaps[0]] = ix[swaps[1]]
+                tmpix[swaps[1]] = ix[swaps[0]]
+                tmpv = np.imag(np.sum(circle_angles(tmpix) * metric[i]))
+                if tmpv < v:
+                    v = tmpv
+                    ix = tmpix
         best_sequence.append(np.roll(ix, -np.where([iix == 0 for iix in ix])[0][0]))
     # Return the best sequence for the chosen metric (in order of counterclockwise
     # rotation)

--- a/osl_dynamics/analysis/tinda.py
+++ b/osl_dynamics/analysis/tinda.py
@@ -223,14 +223,20 @@ def compute_fo_stats(
             temp_to_list = [temp_to[k] for k in np.where(mask == 1)[0]]
             temp_away_list = [temp_away[k] for k in np.where(mask == 1)[0]]
 
-            # Originally, we were concatenating the arrays and then taking the mean, 
-            # but the intervals can be of different lengths (equivalent to weight each intervals with its duration?). 
+            # Originally, we were concatenating the arrays and then taking the mean,
+            # but the intervals can be of different lengths (equivalent to weight each intervals with its duration?).
             # Instead, we take the temporal mean of each interval and then take the mean of those means.
-            interval_weighted_avg[:, 0, j] = np.mean([tmp_to.mean(0) for tmp_to in temp_to_list], axis=0)
-            interval_weighted_avg[:, 1, j] = np.mean([tmp_away.mean(0) for tmp_away in temp_away_list], axis=0)
-            #TODO I am not sure what we should do about the sum.
-            interval_sum[:, 0, j] = np.sum(np.concatenate(temp_away_list, axis = 0), axis=0)
-            interval_sum[:, 1, j] = np.sum(np.concatenate(temp_to_list, axis = 0), axis=0)
+            interval_weighted_avg[:, 0, j] = np.mean(
+                [tmp_to.mean(0) for tmp_to in temp_to_list], axis=0
+            )
+            interval_weighted_avg[:, 1, j] = np.mean(
+                [tmp_away.mean(0) for tmp_away in temp_away_list], axis=0
+            )
+            # TODO I am not sure what we should do about the sum.
+            interval_sum[:, 0, j] = np.sum(
+                np.concatenate(temp_away_list, axis=0), axis=0
+            )
+            interval_sum[:, 1, j] = np.sum(np.concatenate(temp_to_list, axis=0), axis=0)
             interval_weighted_avg_all.append(
                 np.transpose(
                     np.stack(
@@ -647,6 +653,7 @@ def optimise_sequence(
     """
     from scipy.special import factorial
     from itertools import permutations
+
     if len(fo_density.shape) == 5:
         fo_density = np.squeeze(fo_density)
 
@@ -672,13 +679,14 @@ def optimise_sequence(
     for i in range(n_metrics):
         ix = np.arange(K)
         v = np.imag(np.sum(circle_angles(ix) * metric[i]))
-        if factorial(K-1) < n_perms:
+        if factorial(K - 1) < n_perms:
             # If the number of permutations is less than n_perms, then we can compute all permutations and find the best one
             def circular_permutations(arr):
                 arr = np.asarray(arr)
                 first = arr[0]
                 rest = arr[1:]
                 return np.array([[first, *p] for p in permutations(rest)])
+
             all_perms = circular_permutations(ix)
             for p in all_perms:
                 tmpv = np.imag(np.sum(circle_angles(p) * metric[i]))

--- a/osl_dynamics/analysis/tinda.py
+++ b/osl_dynamics/analysis/tinda.py
@@ -220,23 +220,15 @@ def compute_fo_stats(
         interval_weighted_avg_all = []
         interval_sum_all = []
         for j, mask in enumerate(interval_mask):
-            temp_to_list = [temp_to[k] for k in np.where(mask == 1)[0]]
-            temp_away_list = [temp_away[k] for k in np.where(mask == 1)[0]]
+            temp_to_flat = np.concatenate([temp_to[k] for k in np.where(mask == 1)[0]])
+            temp_away_flat = np.concatenate(
+                [temp_away[k] for k in np.where(mask == 1)[0]]
+            )
 
-            # Originally, we were concatenating the arrays and then taking the mean,
-            # but the intervals can be of different lengths (equivalent to weight each intervals with its duration?).
-            # Instead, we take the temporal mean of each interval and then take the mean of those means.
-            interval_weighted_avg[:, 0, j] = np.mean(
-                [tmp_to.mean(0) for tmp_to in temp_to_list], axis=0
-            )
-            interval_weighted_avg[:, 1, j] = np.mean(
-                [tmp_away.mean(0) for tmp_away in temp_away_list], axis=0
-            )
-            # TODO I am not sure what we should do about the sum.
-            interval_sum[:, 0, j] = np.sum(
-                np.concatenate(temp_away_list, axis=0), axis=0
-            )
-            interval_sum[:, 1, j] = np.sum(np.concatenate(temp_to_list, axis=0), axis=0)
+            interval_weighted_avg[:, 0, j] = np.mean(temp_away_flat, axis=0)
+            interval_weighted_avg[:, 1, j] = np.mean(temp_to_flat, axis=0)
+            interval_sum[:, 0, j] = np.sum(temp_away_flat, axis=0)
+            interval_sum[:, 1, j] = np.sum(temp_to_flat, axis=0)
             interval_weighted_avg_all.append(
                 np.transpose(
                     np.stack(

--- a/osl_dynamics/analysis/tinda.py
+++ b/osl_dynamics/analysis/tinda.py
@@ -14,7 +14,7 @@ See Also
 
 import logging
 import math
-from itertools import permutations
+from itertools import islice, permutations
 from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
@@ -649,13 +649,8 @@ def optimise_sequence(
         Best sequence of states to plot (in order of counterclockwise
         rotation).
     """
-    if fo_density.ndim == 5:
-        if fo_density.shape[3] != 1:
-            raise ValueError(
-                "fo_density contains multiple interval ranges, please select "
-                "one, e.g. fo_density[:, :, :, i, :]."
-            )
-        fo_density = np.squeeze(fo_density, axis=3)
+    if len(fo_density.shape) == 5:
+        fo_density = np.squeeze(fo_density)
 
     # Make sure there are no nans (without modifying the input array):
     fo_density = np.where(np.isnan(fo_density), 0, fo_density)
@@ -689,20 +684,48 @@ def optimise_sequence(
         return np.imag(np.sum(circle_angles(order) * metric))
 
     ix = np.arange(K)
-    v = score(ix)
     if math.factorial(K - 1) <= n_perms:
         # There are fewer distinct circular orderings than n_perms, so we can
         # evaluate all of them and find the best one. Fixing the first state
         # removes rotational duplicates, leaving (K-1)! orderings.
-        for p in permutations(range(1, K)):
-            candidate = np.array((0, *p))
-            tmpv = score(candidate)
-            if tmpv < v:
-                v = tmpv
-                ix = candidate
+        #
+        # For a real metric M the score Im(sum(circle_angles(order) * M))
+        # expands to sum_ij sin(theta_j - theta_i) M_ij = c^T M s - s^T M c,
+        # where theta_i is the circle position assigned to state i,
+        # c = cos(theta) and s = sin(theta). This means a whole block of
+        # orderings can be scored with two matrix products. Evaluating in
+        # blocks keeps peak memory to a few tens of MB.
+        phi = 2 * np.pi * np.arange(1, K + 1) / K  # circle positions
+        cos_phi = np.cos(phi)
+        sin_phi = np.sin(phi)
+
+        block_size = 100_000
+        best_v = np.inf
+        all_perms = permutations(range(1, K))
+        while True:
+            block = list(islice(all_perms, block_size))
+            if not block:
+                break
+            perms = np.zeros((len(block), K), dtype=int)
+            perms[:, 1:] = block
+            # State perms[p, a] sits at circle position a, i.e.
+            # theta[perms[p, a]] = phi[a]
+            rows = np.arange(len(block))[:, np.newaxis]
+            c = np.empty((len(block), K))
+            s = np.empty((len(block), K))
+            c[rows, perms] = cos_phi
+            s[rows, perms] = sin_phi
+            v_block = np.einsum("pi,pi->p", c, s @ metric.T) - np.einsum(
+                "pi,pi->p", s, c @ metric.T
+            )
+            best_in_block = np.argmin(v_block)
+            if v_block[best_in_block] < best_v:
+                best_v = v_block[best_in_block]
+                ix = perms[best_in_block].copy()
     else:
         # Too many orderings to evaluate exhaustively, do a random
         # pairwise-swap search
+        v = score(ix)
         for _ in range(n_perms):
             swaps = np.random.permutation(K)[:2]
             candidate = ix.copy()

--- a/osl_dynamics/analysis/tinda.py
+++ b/osl_dynamics/analysis/tinda.py
@@ -13,6 +13,8 @@ See Also
 """
 
 import logging
+import math
+from itertools import permutations
 from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
@@ -213,17 +215,27 @@ def compute_fo_stats(
         temp_to = []
         temp_away = []
         for i in intervals:
-            d = int(np.floor((np.diff(i) - 1) / 2))
+            d = (i[1] - i[0] - 1) // 2
             temp_away.append(tc_sec[i[0] : i[0] + d + 1, :])
             temp_to.append(tc_sec[i[1] - d - 1 : i[1], :])
 
         interval_weighted_avg_all = []
         interval_sum_all = []
         for j, mask in enumerate(interval_mask):
-            temp_to_flat = np.concatenate([temp_to[k] for k in np.where(mask == 1)[0]])
-            temp_away_flat = np.concatenate(
-                [temp_away[k] for k in np.where(mask == 1)[0]]
-            )
+            selected = np.where(mask == 1)[0]
+            if len(selected) == 0:
+                _logger.warning(
+                    f"No intervals with a duration in interval range {j}, "
+                    "returning NaNs for this range."
+                )
+                interval_weighted_avg[:, :, j] = np.nan
+                interval_sum[:, :, j] = np.nan
+                interval_weighted_avg_all.append(np.zeros((tc_sec.shape[1], 2, 0)))
+                interval_sum_all.append(np.zeros((tc_sec.shape[1], 2, 0)))
+                continue
+
+            temp_to_flat = np.concatenate([temp_to[k] for k in selected])
+            temp_away_flat = np.concatenate([temp_away[k] for k in selected])
 
             interval_weighted_avg[:, 0, j] = np.mean(temp_away_flat, axis=0)
             interval_weighted_avg[:, 1, j] = np.mean(temp_to_flat, axis=0)
@@ -234,17 +246,11 @@ def compute_fo_stats(
                     np.stack(
                         [
                             np.stack(
-                                [
-                                    temp_away[k].mean(axis=0)
-                                    for k in np.where(mask == 1)[0]
-                                ],
+                                [temp_away[k].mean(axis=0) for k in selected],
                                 axis=-1,
                             ),
                             np.stack(
-                                [
-                                    temp_to[k].mean(axis=0)
-                                    for k in np.where(mask == 1)[0]
-                                ],
+                                [temp_to[k].mean(axis=0) for k in selected],
                                 axis=-1,
                             ),
                         ]
@@ -257,17 +263,11 @@ def compute_fo_stats(
                     np.stack(
                         [
                             np.stack(
-                                [
-                                    temp_away[k].sum(axis=0)
-                                    for k in np.where(mask == 1)[0]
-                                ],
+                                [temp_away[k].sum(axis=0) for k in selected],
                                 axis=-1,
                             ),
                             np.stack(
-                                [
-                                    temp_to[k].sum(axis=0)
-                                    for k in np.where(mask == 1)[0]
-                                ],
+                                [temp_to[k].sum(axis=0) for k in selected],
                                 axis=-1,
                             ),
                         ]
@@ -628,7 +628,7 @@ def optimise_sequence(
     fo_density : array_like
         Time-in-state densities array of shape (n_interval_states,
         n_density_states, 2, n_sessions).
-    metric : int, optional
+    metric_to_use : int, optional
         Metric to use for optimisation:
 
         - :code:`0`: mean FO asymmetry.
@@ -636,72 +636,85 @@ def optimise_sequence(
           of a baseline - which time spend in the state).
         - :code:`2`: proportional FO asymmetry using global baseline FO, rather
           than a individual-specific baseline.
+    n_perms : int, optional
+        Maximum number of permutations to evaluate. If the number of distinct
+        circular orderings of the K states, (K-1)!, does not exceed
+        :code:`n_perms`, all of them are evaluated and the returned sequence
+        is exact. Otherwise, a random pairwise-swap search with
+        :code:`n_perms` iterations is used.
 
     Returns
     -------
-    best_sequence : list
-        List of best sequence of states to plot (in order of counterclockwise
+    best_sequence : array_like
+        Best sequence of states to plot (in order of counterclockwise
         rotation).
     """
-    from scipy.special import factorial
-    from itertools import permutations
+    if fo_density.ndim == 5:
+        if fo_density.shape[3] != 1:
+            raise ValueError(
+                "fo_density contains multiple interval ranges, please select "
+                "one, e.g. fo_density[:, :, :, i, :]."
+            )
+        fo_density = np.squeeze(fo_density, axis=3)
 
-    if len(fo_density.shape) == 5:
-        fo_density = np.squeeze(fo_density)
-
-    # make sure there are no nans:
-    fo_density[np.isnan(fo_density)] = 0
+    # Make sure there are no nans (without modifying the input array):
+    fo_density = np.where(np.isnan(fo_density), 0, fo_density)
 
     # Compute different metrics to optimise
-    metric = []
-    metric.append(np.mean(fo_density[:, :, 0, :] - fo_density[:, :, 1, :], axis=2))
+    metrics = []
+    metrics.append(np.mean(fo_density[:, :, 0, :] - fo_density[:, :, 1, :], axis=2))
     temp = (fo_density[:, :, 0, :] - fo_density[:, :, 1, :]) / np.mean(
         fo_density, axis=2
     )
-    temp[np.isnan(temp)] = 0
-    metric.append(np.mean(temp, axis=2))
-    metric.append(
+    temp[~np.isfinite(temp)] = 0
+    metrics.append(np.mean(temp, axis=2))
+    metrics.append(
         np.mean(fo_density[:, :, 0, :] - fo_density[:, :, 1, :], axis=2)
         / np.mean(fo_density, axis=(2, 3))
     )
-    n_metrics = len(metric)
+    metric = metrics[metric_to_use]
+    if not np.all(np.isfinite(metric)):
+        _logger.warning(
+            "The metric contains non-finite values (e.g. for states that are "
+            "never active), setting them to zero."
+        )
+        metric[~np.isfinite(metric)] = 0
+
     K = fo_density.shape[0]
+    if K < 3:
+        # There is only one circular ordering
+        return np.arange(K)
 
-    best_sequence = []
-    for i in range(n_metrics):
-        ix = np.arange(K)
-        v = np.imag(np.sum(circle_angles(ix) * metric[i]))
-        if factorial(K - 1) < n_perms:
-            # If the number of permutations is less than n_perms, then we can compute all permutations and find the best one
-            def circular_permutations(arr):
-                arr = np.asarray(arr)
-                first = arr[0]
-                rest = arr[1:]
-                return np.array([[first, *p] for p in permutations(rest)])
+    def score(order):
+        return np.imag(np.sum(circle_angles(order) * metric))
 
-            all_perms = circular_permutations(ix)
-            for p in all_perms:
-                tmpv = np.imag(np.sum(circle_angles(p) * metric[i]))
-                if tmpv < v:
-                    v = tmpv
-                    ix = p
-        else:
-            cnt = 0
-            while cnt < n_perms:
-                cnt += 1
-                swaps = np.random.permutation(K)
-                swaps = swaps[:2]
-                tmpix = ix.copy()
-                tmpix[swaps[0]] = ix[swaps[1]]
-                tmpix[swaps[1]] = ix[swaps[0]]
-                tmpv = np.imag(np.sum(circle_angles(tmpix) * metric[i]))
-                if tmpv < v:
-                    v = tmpv
-                    ix = tmpix
-        best_sequence.append(np.roll(ix, -np.where([iix == 0 for iix in ix])[0][0]))
-    # Return the best sequence for the chosen metric (in order of counterclockwise
-    # rotation)
-    return best_sequence[metric_to_use]
+    ix = np.arange(K)
+    v = score(ix)
+    if math.factorial(K - 1) <= n_perms:
+        # There are fewer distinct circular orderings than n_perms, so we can
+        # evaluate all of them and find the best one. Fixing the first state
+        # removes rotational duplicates, leaving (K-1)! orderings.
+        for p in permutations(range(1, K)):
+            candidate = np.array((0, *p))
+            tmpv = score(candidate)
+            if tmpv < v:
+                v = tmpv
+                ix = candidate
+    else:
+        # Too many orderings to evaluate exhaustively, do a random
+        # pairwise-swap search
+        for _ in range(n_perms):
+            swaps = np.random.permutation(K)[:2]
+            candidate = ix.copy()
+            candidate[swaps[0]], candidate[swaps[1]] = ix[swaps[1]], ix[swaps[0]]
+            tmpv = score(candidate)
+            if tmpv < v:
+                v = tmpv
+                ix = candidate
+
+    # Return the best sequence (in order of counterclockwise rotation),
+    # rotated so it starts with state 0
+    return np.roll(ix, -np.where(ix == 0)[0][0])
 
 
 def compute_cycle_strength(


### PR DESCRIPTION
- Change TINDA calculation such that we are taking the mean of the intervals instead of concatenating and taking the mean,
- Optimize `optimise_sequence()` when the number of states is low. 